### PR TITLE
Fix neo4j cypher in _create_nodes

### DIFF
--- a/aas_mapping/aas_neo4j_adapter/jsonification/neo4j_import.py
+++ b/aas_mapping/aas_neo4j_adapter/jsonification/neo4j_import.py
@@ -65,7 +65,7 @@ class JsonToNeo4jImporter(BaseNeo4JClient):
         WITH split(labelsString, ",") AS labels, $data[labelsString] AS nodesProperties
         
         UNWIND nodesProperties AS nodeProperties
-        CREATE (n:$(labels))
+        CALL apoc.create.node(labels, nodeProperties) YIELD node AS n
         SET n = nodeProperties
         
         RETURN elementId(n) AS internal_id, nodeProperties.uid AS uid


### PR DESCRIPTION
Currently, the cypher in the _create_nodes function throws an error due to the usage of parameter in the label creation.

Now it uses apoc plugin to do this.

Fixes #12