### PR TITLE
Implement Neo4jObjectStore.commit()

### DIFF
--- a/aas_mapping/aas_neo4j_adapter/neo_aas_object_store.py
+++ b/aas_mapping/aas_neo4j_adapter/neo_aas_object_store.py
@@ -35,6 +35,14 @@ class Neo4jObjectStore(AbstractObjectStore[Identifier, Identifiable]):
         obj = json.loads(json.dumps(data), cls=StrictAASFromJsonDecoder)
         return obj
 
+    def commit(self, x: Identifiable) -> None:
+        if not self._client.identifiable_exists(x.id):
+            raise KeyError(f"Identifiable object with id {x.id} not found in Neo4j store")
+        self._client.remove_identifiable(x.id)
+        data = json.dumps(obj=x, cls=AASToJsonEncoder)
+        data_dict = json.loads(data)
+        self._client.add_identifiable(data_dict)
+
     def discard(self, x: Identifiable) -> None:
         self._client.remove_identifiable(x.id)
 


### PR DESCRIPTION
AbstractObjectStore.commit() raised NotImplementedError, so any PUT/PATCH/DELETE on a submodel element via the repository server failed with a 500 once the in-memory mutation needed to be persisted.

Implement commit() by removing the identifiable's existing subgraph and re-adding it from the updated in-memory object, mirroring the delete-then-add pattern already used by discard()/add().