### PR TITLE
[WIP] Feat/mpc server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ aas_mapping/
 │       ├── ast_nodes.py         # AST node type definitions
 │       ├── ast_to_cypher.py     # AST → Cypher (compiler)
 │       └── aasql_to_cypher.py   # Entry point: convert_aasql_to_cypher()
+├── mcp_server/
+│   ├── server.py                # MCP tool definitions (FastMCP)
+│   ├── abstract.py              # Template-submodel merge logic
+│   ├── config.py                # Neo4j connection config (from env)
+│   ├── __init__.py
+│   └── __main__.py              # CLI entry point
 ├── examples/
 │   ├── queries/                 # Example AASQL queries (JSON)
 │   ├── ast/                     # Expected AST representations
@@ -30,7 +36,8 @@ aas_mapping/
 └── test/
     ├── test_aasql2ast.py        # Unit tests for AASQL → AST parsing
     ├── test_roundtrip.py        # Integration: JSON and XML ↔ Neo4j round-trip tests
-    └── test_constraint_checker.py  # Unit + integration tests for AASConstraintChecker
+    ├── test_constraint_checker.py  # Unit + integration tests for AASConstraintChecker
+    └── test_mcp_server.py       # Unit + integration tests for MCP server
 ```
 
 ---
@@ -273,6 +280,89 @@ print(report.summary())
 | AASd-131 | `AssetInformation` must have `globalAssetId` or at least one `specificAssetId` |
 | AASd-133 | `SpecificAssetId.externalSubjectId` must be an `ExternalReference` |
 | AASd-134 | Operation variable `idShort`s must be unique across in/out/inout |
+
+---
+
+## MCP Server
+
+A read-only [Model Context Protocol](https://modelcontextprotocol.io/) server exposes the Neo4j-backed graph to MCP clients (Claude Desktop, Claude Code, ...), so the data can be read, queried and validated in natural language.
+
+### Install
+
+```bash
+pip install ".[mcp]"
+```
+
+### Run
+
+```bash
+python -m aas_mapping.mcp_server      # or: aas4graph-mcp
+```
+
+Connection is configured via environment variables (defaults shown):
+
+| Variable | Default |
+|---|---|
+| `NEO4J_URI` | `bolt://localhost:7687` |
+| `NEO4J_USER` | `neo4j` |
+| `NEO4J_PASSWORD` | `12345678` |
+
+### Tools
+
+| Tool | Description |
+|---|---|
+| `count_stats` | Count of Identifiable / Referable nodes (health check) |
+| `get_identifiable` | Fetch an AAS / Submodel / ConceptDescription by `id` |
+| `get_referable` | Fetch a Referable by parent `id` + `idShortPath` |
+| `compile_aasql` | Compile an AASQL query to Cypher (no execution) |
+| `query_aasql` | Compile an AASQL query and execute it, returning rows |
+| `validate_constraints` | Run AAS spec constraint validation, returning a report |
+| `list_submodels` | Paginated list of all Submodels with id, idShort, kind, semanticId |
+| `list_submodel_types` | Distinct Submodel types (idShort + semanticId) with instance count each |
+| `abstract_submodel` | Build a Template-kind structural union from all Submodels of a given type |
+
+All tools are read-only; none mutate the graph.
+
+#### `list_submodels` — pagination
+
+Large graphs can have hundreds of thousands of Submodels. Use `limit` and `offset` to page:
+
+```
+list_submodels(limit=50, offset=0)   # first 50
+list_submodels(limit=50, offset=50)  # next 50
+```
+
+The response includes `total` (full count), `limit`, `offset`, and `submodels`.
+
+#### `abstract_submodel` — type matching and output format
+
+`submodel_type` is matched against `idShort` by default. If the value contains `://` or starts with `urn:`, it is matched against the Submodel's `semanticId` instead:
+
+```
+abstract_submodel("DigitalNameplate")
+abstract_submodel("https://admin-shell.io/zvei/nameplate/2/0/Nameplate")
+abstract_submodel("DigitalNameplate", output_format="yaml")
+```
+
+### Claude Desktop config
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "aas4graph": {
+      "command": "python",
+      "args": ["-m", "aas_mapping.mcp_server"],
+      "env": {
+        "NEO4J_URI": "bolt://localhost:7687",
+        "NEO4J_USER": "neo4j",
+        "NEO4J_PASSWORD": "12345678"
+      }
+    }
+  }
+}
+```
 
 ---
 

--- a/aas_mapping/aas_neo4j_adapter/aas_neo4j_client.py
+++ b/aas_mapping/aas_neo4j_adapter/aas_neo4j_client.py
@@ -206,6 +206,40 @@ class AASNeo4JClient(XmlToNeo4jImporter, JsonFromNeo4jExporter):
     def get_identifiable(self, identifier: str) -> Dict:
         return self.get_referable(identifier)
 
+    def get_identifiables_by_type(
+        self,
+        submodel_type: str,
+        by_semantic_id: bool = False,
+    ) -> list[Dict]:
+        """Fetch all Submodels of a given type in a single Neo4j query.
+
+        Uses one session and one APOC call per matched submodel (batched via
+        Cypher iteration) instead of N separate round-trips.
+        """
+        if by_semantic_id:
+            match_clause = (
+                "MATCH (sm:Submodel)-[:semanticId]->(sem:Reference) "
+                "WHERE sem.keys_value[0] = $type "
+            )
+        else:
+            match_clause = "MATCH (sm:Submodel {idShort: $type}) "
+
+        cypher = (
+            match_clause
+            + "CALL apoc.path.subgraphAll(sm, {relationshipFilter: '>'}) YIELD nodes, relationships "
+            "WITH sm, nodes "
+            "OPTIONAL MATCH (a)-[r]->(b) WHERE a IN nodes AND b IN nodes "
+            "WITH sm, nodes, collect(r) AS allRels "
+            "RETURN apoc.convert.toJson({nodes: nodes, relationships: allRels}) AS json"
+        )
+        rows = self.execute_clause(cypher, params={"type": submodel_type}) or []
+        return [
+            self._strip_internal_keys(
+                self.convert_subgraph_to_data_dict(json.loads(row["json"]))
+            )
+            for row in rows
+        ]
+
     def count_nodes_with_label(self, label: str) -> int:
         """Count the number of nodes with a specific label."""
         clause = f"MATCH (n:{label}) RETURN COUNT(n) AS count"

--- a/aas_mapping/mcp_server/__init__.py
+++ b/aas_mapping/mcp_server/__init__.py
@@ -1,0 +1,5 @@
+"""MCP server exposing the aas4graph Neo4j adapter as Model Context Protocol tools."""
+
+from aas_mapping.mcp_server.server import mcp
+
+__all__ = ["mcp"]

--- a/aas_mapping/mcp_server/__main__.py
+++ b/aas_mapping/mcp_server/__main__.py
@@ -1,0 +1,6 @@
+"""Allow `python -m aas_mapping.mcp_server`."""
+
+from aas_mapping.mcp_server.server import main
+
+if __name__ == "__main__":
+    main()

--- a/aas_mapping/mcp_server/abstract.py
+++ b/aas_mapping/mcp_server/abstract.py
@@ -1,0 +1,109 @@
+"""Build an abstract (Template-kind) submodel from a list of AAS JSON instances.
+
+The result is the structural union of all instances: every element path that
+appears in at least one instance is included, instance-specific values are
+stripped, and kind is set to "Template".
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+# Model types whose "value" is an instance value (scalar/blob/ref), not children.
+_LEAF_TYPES = frozenset(
+    {
+        "Property",
+        "MultiLanguageProperty",
+        "Range",
+        "Blob",
+        "File",
+        "ReferenceElement",
+        "RelationshipElement",
+        "AnnotatedRelationshipElement",
+    }
+)
+
+# Model types whose "value" or "submodelElements" is a list of child elements.
+_CONTAINER_TYPES = frozenset({"Submodel", "SubmodelElementCollection"})
+
+_INTERNAL_KEYS = frozenset({"uid", "hash"})
+
+
+def to_template(element: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep-copied, value-stripped Template version of *element*."""
+    result: dict[str, Any] = {
+        k: v for k, v in element.items() if k not in _INTERNAL_KEYS
+    }
+    model_type = element.get("modelType", "")
+
+    if model_type == "Submodel":
+        result["kind"] = "Template"
+        id_short = element.get("idShort", "unknown")
+        result["id"] = f"abstract:{id_short}"
+        result.pop("administration", None)
+        children = element.get("submodelElements", [])
+        result["submodelElements"] = [to_template(c) for c in children]
+
+    elif model_type == "SubmodelElementCollection":
+        children = element.get("value", [])
+        result["value"] = [to_template(c) for c in children]
+
+    elif model_type == "SubmodelElementList":
+        # Keep one representative child to show element type.
+        children = element.get("value", [])
+        result["value"] = [to_template(children[0])] if children else []
+
+    elif model_type in _LEAF_TYPES:
+        result.pop("value", None)
+        result.pop("min", None)
+        result.pop("max", None)
+
+    return result
+
+
+def _children_key(model_type: str) -> str:
+    return "submodelElements" if model_type == "Submodel" else "value"
+
+
+def _merge_structure(base: dict[str, Any], other: dict[str, Any]) -> None:
+    """Merge missing element paths from *other* into *base* in-place."""
+    model_type = base.get("modelType", "")
+    if model_type not in _CONTAINER_TYPES:
+        return
+
+    key = _children_key(model_type)
+    base_children: list[dict] = base.setdefault(key, [])
+    other_children: list[dict] = other.get(key, [])
+
+    base_index = {c["idShort"]: c for c in base_children if "idShort" in c}
+
+    for other_child in other_children:
+        id_short = other_child.get("idShort")
+        if id_short is None:
+            continue
+        if id_short not in base_index:
+            # Element exists in other but not in base — add it.
+            base_children.append(copy.deepcopy(other_child))
+            base_index[id_short] = base_children[-1]
+        else:
+            # Both have this element — recurse to merge nested structure.
+            _merge_structure(base_index[id_short], other_child)
+
+
+def build_abstract_submodel(instances: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return a Template submodel that is the structural union of *instances*.
+
+    Each instance must be a full AAS JSON submodel dict as returned by
+    ``AASNeo4JClient.get_identifiable()``.
+
+    Raises ``ValueError`` if *instances* is empty.
+    """
+    if not instances:
+        raise ValueError("No submodel instances provided.")
+
+    abstract = to_template(instances[0])
+    for other in instances[1:]:
+        _merge_structure(abstract, to_template(other))
+
+    return abstract

--- a/aas_mapping/mcp_server/config.py
+++ b/aas_mapping/mcp_server/config.py
@@ -1,0 +1,25 @@
+"""Configuration for the aas4graph MCP server, sourced from environment variables."""
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Neo4jConnectionConfig:
+    """Neo4j connection parameters for the MCP server."""
+
+    uri: str
+    user: str
+    password: str
+
+    @classmethod
+    def from_env(cls) -> "Neo4jConnectionConfig":
+        """Build connection config from NEO4J_* environment variables.
+
+        Falls back to the local-development defaults documented in the README.
+        """
+        return cls(
+            uri=os.environ.get("NEO4J_URI", "bolt://localhost:7687"),
+            user=os.environ.get("NEO4J_USER", "neo4j"),
+            password=os.environ.get("NEO4J_PASSWORD", "12345678"),
+        )

--- a/aas_mapping/mcp_server/server.py
+++ b/aas_mapping/mcp_server/server.py
@@ -1,0 +1,333 @@
+"""
+aas4graph MCP server (read-only, stdio transport).
+
+Exposes the Neo4j-backed AAS graph as Model Context Protocol tools so that MCP
+clients (Claude Desktop, Claude Code, ...) can read, query and validate AAS data
+stored in Neo4j.
+
+All tools are read-only: nothing in this module mutates the graph.
+
+Run with::
+
+    python -m aas_mapping.mcp_server
+
+Connection is configured via the NEO4J_URI / NEO4J_USER / NEO4J_PASSWORD
+environment variables (see config.py for defaults).
+"""
+
+import logging
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Literal, Optional
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from aas_mapping.aas_neo4j_adapter.aas_neo4j_client import (
+    AAS_NEO4J_MODEL_CONFIG,
+    AASNeo4JClient,
+)
+from aas_mapping.aas_neo4j_adapter.querification.aasql_to_ast import parse_aasql_query
+from aas_mapping.aas_neo4j_adapter.querification.ast_to_cypher import converter
+from aas_mapping.aas_neo4j_adapter.validation import AASConstraintChecker
+from aas_mapping.mcp_server.abstract import build_abstract_submodel
+from aas_mapping.mcp_server.config import Neo4jConnectionConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AppContext:
+    """Shared state held for the lifetime of the server process."""
+
+    client: AASNeo4JClient
+
+
+@asynccontextmanager
+async def lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
+    """Open a single Neo4j-backed client at startup, close it at shutdown."""
+    cfg = Neo4jConnectionConfig.from_env()
+    logger.info("Connecting to Neo4j at %s as %s", cfg.uri, cfg.user)
+    client = AASNeo4JClient(
+        uri=cfg.uri,
+        user=cfg.user,
+        password=cfg.password,
+        model_config=AAS_NEO4J_MODEL_CONFIG,
+    )
+    try:
+        yield AppContext(client=client)
+    finally:
+        if client.driver is not None:
+            client.driver.close()
+
+
+mcp = FastMCP("aas4graph", lifespan=lifespan)
+
+
+def _client(ctx: Context) -> AASNeo4JClient:
+    return ctx.request_context.lifespan_context.client
+
+
+# ---------------------------------------------------------------------------
+# Read tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def count_stats(ctx: Context) -> dict[str, int]:
+    """Return graph health counts: number of Identifiable and Referable nodes.
+
+    Cheap sanity check that the graph is reachable and populated.
+    """
+    client = _client(ctx)
+    return {
+        "identifiables": client.count_identifiables(),
+        "referables": client.count_referables(),
+    }
+
+
+@mcp.tool()
+def get_identifiable(identifier: str, ctx: Context) -> dict[str, Any]:
+    """Fetch a top-level Identifiable (AssetAdministrationShell, Submodel or
+    ConceptDescription) by its global `id`, returned as an AAS JSON object.
+
+    Args:
+        identifier: The global `id` of the Identifiable (e.g. a URI/IRI).
+    """
+    return _client(ctx).get_identifiable(identifier)
+
+
+@mcp.tool()
+def get_referable(
+    parent_id: str,
+    ctx: Context,
+    id_short_path: Optional[str] = None,
+) -> dict[str, Any]:
+    """Fetch a Referable as an AAS JSON object.
+
+    Args:
+        parent_id: Global `id` of the containing Identifiable.
+        id_short_path: Dot/bracket path to the nested element, e.g.
+            "MyCollection.MyList[0].MyProperty". Omit to fetch the Identifiable
+            itself (same as get_identifiable).
+    """
+    return _client(ctx).get_referable(parent_id, id_short_path)
+
+
+def _validate_aasql(query: Any) -> None:
+    """Cheap structural check so callers get a clear error instead of a cryptic
+    parser exception (KeyError / TypeError). Deep validation is left to the parser.
+    """
+    if not isinstance(query, dict):
+        raise ValueError(
+            f"AASQL query must be a JSON object, got {type(query).__name__}."
+        )
+    if "$condition" not in query:
+        raise ValueError("AASQL query must contain a top-level '$condition' key.")
+
+
+@mcp.tool()
+def compile_aasql(query: dict[str, Any]) -> str:
+    """Compile an AASQL query (JSON object) to a Cypher string WITHOUT executing it.
+
+    AASQL roots: $aas, $sm, $cd, $sme.<idShort>.
+    Field syntax: {"$field": "$<root>#<attribute>[.<nested>]"}.
+    Operators: comparison ($eq $ne $gt $ge $lt $le), string ($contains
+    $starts-with $ends-with $regex), logical ($and $or $not), list ($match),
+    casts ($strCast $numCast $hexCast $boolCast $dateTimeCast $timeCast).
+
+    Example query:
+        {"$condition": {"$eq": [{"$field": "$aas#idShort"},
+                                 {"$strVal": "MyShell"}]}}
+    """
+    # Call parse + convert directly: convert_aasql_to_cypher() prints to stdout,
+    # which would corrupt the stdio MCP protocol channel.
+    _validate_aasql(query)
+    ast = parse_aasql_query(query)
+    return converter(ast)
+
+
+@mcp.tool()
+def query_aasql(query: dict[str, Any], ctx: Context) -> dict[str, Any]:
+    """Compile an AASQL query (JSON object) to Cypher and execute it against Neo4j.
+
+    Returns the generated Cypher plus the result rows. See compile_aasql for the
+    AASQL syntax reference.
+    """
+    cypher = compile_aasql(query)
+    rows = _client(ctx).execute_clause(cypher) or []
+    results = [AASNeo4JClient._strip_internal_keys(row.data()) for row in rows]
+    return {"cypher": cypher, "count": len(results), "results": results}
+
+
+@mcp.tool()
+def validate_constraints(
+    ctx: Context,
+    constraint_ids: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """Validate AAS data in Neo4j against the AAS specification constraints.
+
+    Args:
+        constraint_ids: Optional subset of constraint IDs (e.g. ["AASd-002",
+            "AASd-022"]). Omit to run all implemented constraints.
+
+    Returns a compliance flag, a human-readable summary, the list of checked
+    constraints, and structured violation records.
+    """
+    checker = AASConstraintChecker(_client(ctx))
+    report = checker.check(constraint_ids) if constraint_ids else checker.check_all()
+    return {
+        "compliant": report.is_compliant(),
+        "summary": report.summary(),
+        "checked_constraints": report.checked_constraints,
+        "violations": [
+            {
+                "constraint_id": v.constraint_id,
+                "description": v.description,
+                "details": v.details,
+            }
+            for v in report.violations
+        ],
+    }
+
+
+_LIST_SUBMODELS_CYPHER = """
+MATCH (sm:Submodel)
+OPTIONAL MATCH (sm)-[:semanticId]->(sem:Reference)
+RETURN sm.id AS id, sm.idShort AS idShort, sm.kind AS kind,
+       sem.keys_value[0] AS semanticId
+ORDER BY sm.idShort
+SKIP $skip LIMIT $limit
+""".strip()
+
+_LIST_SUBMODELS_COUNT_CYPHER = "MATCH (sm:Submodel) RETURN COUNT(sm) AS total"
+
+_LIST_SUBMODEL_TYPES_CYPHER = """
+MATCH (sm:Submodel)
+OPTIONAL MATCH (sm)-[:semanticId]->(sem:Reference)
+RETURN sm.idShort AS idShort, sem.keys_value[0] AS semanticId, COUNT(sm) AS count
+ORDER BY count DESC, idShort
+""".strip()
+
+_DEFAULT_LIMIT = 100
+
+
+@mcp.tool()
+def list_submodels(
+    ctx: Context,
+    limit: int = _DEFAULT_LIMIT,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List Submodels in the graph with their id, idShort, kind, and semanticId.
+
+    Returns a paginated list — use offset to page through large graphs.
+
+    Args:
+        limit: Maximum number of submodels to return (default 100).
+        offset: Number of submodels to skip (default 0).
+    """
+    client = _client(ctx)
+    total_row = client.execute_clause(_LIST_SUBMODELS_COUNT_CYPHER, single=True)
+    total = total_row["total"] if total_row else 0
+    rows = client.execute_clause(
+        _LIST_SUBMODELS_CYPHER, params={"skip": offset, "limit": limit}
+    ) or []
+    submodels = [
+        {
+            "id": row["id"],
+            "idShort": row["idShort"],
+            "kind": row["kind"],
+            "semanticId": row["semanticId"],
+        }
+        for row in rows
+    ]
+    return {
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "submodels": submodels,
+    }
+
+
+@mcp.tool()
+def list_submodel_types(ctx: Context) -> dict[str, Any]:
+    """List distinct Submodel types in the graph with an instance count each.
+
+    Groups by idShort and semanticId, sorted by count descending. Useful to
+    discover which types exist before calling abstract_submodel.
+    """
+    rows = _client(ctx).execute_clause(_LIST_SUBMODEL_TYPES_CYPHER) or []
+    types = [
+        {
+            "idShort": row["idShort"],
+            "semanticId": row["semanticId"],
+            "count": row["count"],
+        }
+        for row in rows
+    ]
+    return {"total_types": len(types), "types": types}
+
+
+def _is_semantic_id(value: str) -> bool:
+    return "://" in value or value.startswith("urn:")
+
+
+@mcp.tool()
+def abstract_submodel(
+    submodel_type: str,
+    ctx: Context,
+    output_format: Literal["json", "yaml"] = "json",
+) -> dict[str, Any]:
+    """Build an abstract Template submodel from all Submodels of a given type.
+
+    Fetches every matching Submodel, strips instance-specific values, and returns
+    the structural union as a Template-kind AAS JSON object.
+
+    Args:
+        submodel_type: The type to abstract. Matched against ``idShort`` by
+            default. If the value contains ``://`` or starts with ``urn:``, it is
+            matched against the Submodel's semanticId instead.
+        output_format: ``"json"`` (default) returns the template as a nested dict
+            under the ``"abstract_submodel"`` key. ``"yaml"`` serialises only the
+            template to a YAML string under the ``"yaml"`` key.
+
+    Raises:
+        ValueError: if no Submodels of the given type are found.
+    """
+    client = _client(ctx)
+
+    instances = client.get_identifiables_by_type(
+        submodel_type,
+        by_semantic_id=_is_semantic_id(submodel_type),
+    )
+
+    if not instances:
+        raise ValueError(
+            f"No Submodels found for type '{submodel_type}'. "
+            "Use list_submodels to browse available types."
+        )
+
+    abstract = build_abstract_submodel(instances)
+
+    if output_format == "yaml":
+        import yaml  # lazy import — optional dep
+
+        return {
+            "instance_count": len(instances),
+            "submodel_type": submodel_type,
+            "yaml": yaml.dump(abstract, allow_unicode=True, sort_keys=False),
+        }
+
+    return {
+        "instance_count": len(instances),
+        "submodel_type": submodel_type,
+        "abstract_submodel": abstract,
+    }
+
+
+def main() -> None:
+    """Entry point: run the server over stdio."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/aas_mapping/test/conftest.py
+++ b/aas_mapping/test/conftest.py
@@ -8,11 +8,54 @@ from aas_mapping.aas_neo4j_adapter.aas_neo4j_client import AASNeo4JClient, AAS_N
 
 @pytest.fixture(scope="session")
 def neo4j_params():
-    return {
-        "uri": os.environ.get("NEO4J_URI", "bolt://localhost:7687"),
-        "user": os.environ.get("NEO4J_USER", "neo4j"),
-        "password": os.environ.get("NEO4J_PASSWORD", "12345678"),
-    }
+    """Neo4j connection parameters for integration tests.
+
+    By default a fresh, disposable Neo4j container is started for the test
+    session (via testcontainers) and torn down afterwards — so integration
+    tests never touch a real database, and the destructive ``aas_client``
+    fixture can only ever wipe the throwaway container.
+
+    To run against an already-running Neo4j instead, set ``NEO4J_URI`` (and
+    optionally ``NEO4J_USER`` / ``NEO4J_PASSWORD``). WARNING: the ``aas_client``
+    fixture wipes that database — never point it at data you want to keep.
+    """
+    # Explicit override: use the provided instance, start no container.
+    if os.environ.get("NEO4J_URI"):
+        yield {
+            "uri": os.environ["NEO4J_URI"],
+            "user": os.environ.get("NEO4J_USER", "neo4j"),
+            "password": os.environ.get("NEO4J_PASSWORD", "12345678"),
+        }
+        return
+
+    # Default: spin up a disposable container for the whole session.
+    try:
+        from testcontainers.neo4j import Neo4jContainer
+    except ImportError:
+        pytest.skip(
+            "testcontainers not installed and NEO4J_URI not set; "
+            "run `pip install \".[test]\"` or set NEO4J_URI to a throwaway DB."
+        )
+
+    container = (
+        Neo4jContainer("neo4j:5", password="12345678")
+        .with_env("NEO4J_PLUGINS", '["apoc"]')
+        .with_env("NEO4J_server_memory_heap_max__size", "1G")
+        .with_env("NEO4J_server_memory_pagecache_size", "512m")
+    )
+    try:
+        container.start()
+    except Exception as exc:  # Docker unavailable, image pull failure, ...
+        pytest.skip(f"Could not start disposable Neo4j container: {exc}")
+
+    try:
+        yield {
+            "uri": container.get_connection_url(),
+            "user": container.username,
+            "password": container.password,
+        }
+    finally:
+        container.stop()
 
 
 @pytest.fixture(scope="session")

--- a/aas_mapping/test/test_mcp_server.py
+++ b/aas_mapping/test/test_mcp_server.py
@@ -1,0 +1,294 @@
+"""Tests for the aas4graph MCP server.
+
+Unit tests use a mocked client and need no Neo4j. Integration tests reuse the
+`aas_client` fixture (skipped automatically when Neo4j is unreachable).
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import anyio
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from aas_mapping.mcp_server import server as mcp_server
+
+
+def _fake_ctx(client):
+    """Build a minimal Context stand-in exposing the lifespan client."""
+    lifespan_context = SimpleNamespace(client=client)
+    request_context = SimpleNamespace(lifespan_context=lifespan_context)
+    return SimpleNamespace(request_context=request_context)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (no Neo4j)
+# ---------------------------------------------------------------------------
+
+
+def test_expected_tools_registered():
+    tools = anyio.run(mcp_server.mcp.list_tools)
+    names = {t.name for t in tools}
+    assert names == {
+        "count_stats",
+        "get_identifiable",
+        "get_referable",
+        "compile_aasql",
+        "query_aasql",
+        "validate_constraints",
+        "list_submodels",
+        "list_submodel_types",
+        "abstract_submodel",
+    }
+
+
+def test_compile_aasql_returns_cypher():
+    query = {
+        "$condition": {
+            "$eq": [{"$field": "$aas#idShort"}, {"$strVal": "MyShell"}]
+        }
+    }
+    cypher = mcp_server.compile_aasql(query)
+    assert isinstance(cypher, str)
+    assert "AssetAdministrationShell" in cypher
+    assert "MyShell" in cypher
+
+
+@pytest.mark.parametrize(
+    "bad_query, expected",
+    [
+        ({}, r"\$condition"),
+        ({"foo": "bar"}, r"\$condition"),
+        ("not-a-dict", "JSON object"),
+        (123, "JSON object"),
+    ],
+)
+def test_compile_aasql_rejects_invalid_query(bad_query, expected):
+    with pytest.raises(ValueError, match=expected):
+        mcp_server.compile_aasql(bad_query)
+
+
+# --- schema-validation path exercised through FastMCP (pydantic + guard) ---
+
+
+def test_call_tool_rejects_missing_required_arg():
+    # get_identifiable requires `identifier`; pydantic rejects the empty args.
+    with pytest.raises(ToolError):
+        anyio.run(mcp_server.mcp.call_tool, "get_identifiable", {})
+
+
+def test_call_tool_rejects_wrong_arg_type():
+    # `query` is typed dict[str, Any]; a string fails pydantic validation.
+    with pytest.raises(ToolError):
+        anyio.run(mcp_server.mcp.call_tool, "query_aasql", {"query": "not-a-dict"})
+
+
+def test_call_tool_compile_aasql_missing_condition():
+    # Passes pydantic (is a dict) but fails the structural guard.
+    with pytest.raises(ToolError, match="condition"):
+        anyio.run(mcp_server.mcp.call_tool, "compile_aasql", {"query": {"foo": "bar"}})
+
+
+def test_count_stats_uses_client():
+    client = MagicMock()
+    client.count_identifiables.return_value = 3
+    client.count_referables.return_value = 42
+    result = mcp_server.count_stats(_fake_ctx(client))
+    assert result == {"identifiables": 3, "referables": 42}
+
+
+def test_query_aasql_strips_internal_keys():
+    client = MagicMock()
+    row = MagicMock()
+    row.data.return_value = {"aas": {"idShort": "X", "uid": 1, "hash": "abc"}}
+    client.execute_clause.return_value = [row]
+
+    query = {
+        "$condition": {
+            "$eq": [{"$field": "$aas#idShort"}, {"$strVal": "X"}]
+        }
+    }
+    result = mcp_server.query_aasql(query, _fake_ctx(client))
+
+    assert result["count"] == 1
+    assert result["results"] == [{"aas": {"idShort": "X"}}]
+    assert "uid" not in result["results"][0]["aas"]
+    client.execute_clause.assert_called_once_with(result["cypher"])
+
+
+def test_get_referable_delegates():
+    client = MagicMock()
+    client.get_referable.return_value = {"idShort": "Color"}
+    out = mcp_server.get_referable("some-id", _fake_ctx(client), id_short_path="Color")
+    assert out == {"idShort": "Color"}
+    client.get_referable.assert_called_once_with("some-id", "Color")
+
+
+def _mock_row(data: dict):
+    row = MagicMock()
+    row.__getitem__ = lambda self, key: data[key]
+    return row
+
+
+def test_list_submodels_returns_shape():
+    client = MagicMock()
+    count_row = MagicMock()
+    count_row.__getitem__ = lambda self, key: 2 if key == "total" else None
+    client.execute_clause.side_effect = [
+        count_row,  # COUNT query (single=True)
+        [  # paginated rows
+            _mock_row({"id": "urn:sm1", "idShort": "Nameplate", "kind": "Instance", "semanticId": "urn:sem1"}),
+            _mock_row({"id": "urn:sm2", "idShort": "Nameplate", "kind": "Instance", "semanticId": "urn:sem1"}),
+        ],
+    ]
+    result = mcp_server.list_submodels(_fake_ctx(client))
+    assert result["total"] == 2
+    assert result["submodels"][0]["id"] == "urn:sm1"
+    assert result["submodels"][0]["idShort"] == "Nameplate"
+    assert result["offset"] == 0
+    assert result["limit"] == 100
+
+
+def test_list_submodels_empty_graph():
+    client = MagicMock()
+    count_row = MagicMock()
+    count_row.__getitem__ = lambda self, key: 0 if key == "total" else None
+    client.execute_clause.side_effect = [count_row, []]
+    result = mcp_server.list_submodels(_fake_ctx(client))
+    assert result["total"] == 0
+    assert result["submodels"] == []
+
+
+def test_list_submodel_types_returns_shape():
+    client = MagicMock()
+    client.execute_clause.return_value = [
+        _mock_row({"idShort": "Nameplate", "semanticId": "urn:sem1", "count": 42}),
+        _mock_row({"idShort": "ContactInformations", "semanticId": "urn:sem2", "count": 7}),
+    ]
+    result = mcp_server.list_submodel_types(_fake_ctx(client))
+    assert result["total_types"] == 2
+    assert result["types"][0] == {"idShort": "Nameplate", "semanticId": "urn:sem1", "count": 42}
+
+
+def test_abstract_submodel_no_match_raises():
+    client = MagicMock()
+    client.get_identifiables_by_type.return_value = []
+    with pytest.raises(ValueError, match="No Submodels found"):
+        mcp_server.abstract_submodel("NonExistent", _fake_ctx(client))
+
+
+def test_abstract_submodel_strips_values():
+    client = MagicMock()
+    client.get_identifiables_by_type.return_value = [
+        {
+            "modelType": "Submodel",
+            "id": "urn:sm1",
+            "idShort": "Doc",
+            "kind": "Instance",
+            "submodelElements": [
+                {"modelType": "Property", "idShort": "Title", "valueType": "xs:string", "value": "Hello"},
+            ],
+        }
+    ]
+    result = mcp_server.abstract_submodel("Doc", _fake_ctx(client))
+    abstract = result["abstract_submodel"]
+    assert abstract["kind"] == "Template"
+    prop = abstract["submodelElements"][0]
+    assert "value" not in prop
+    assert prop["valueType"] == "xs:string"
+
+
+def test_abstract_submodel_merges_structure():
+    client = MagicMock()
+    client.get_identifiables_by_type.return_value = [
+        {
+            "modelType": "Submodel",
+            "id": "urn:sm1",
+            "idShort": "Doc",
+            "kind": "Instance",
+            "submodelElements": [
+                {"modelType": "Property", "idShort": "Title", "valueType": "xs:string", "value": "A"},
+            ],
+        },
+        {
+            "modelType": "Submodel",
+            "id": "urn:sm2",
+            "idShort": "Doc",
+            "kind": "Instance",
+            "submodelElements": [
+                {"modelType": "Property", "idShort": "Title", "valueType": "xs:string", "value": "B"},
+                {"modelType": "Property", "idShort": "Author", "valueType": "xs:string", "value": "X"},
+            ],
+        },
+    ]
+    result = mcp_server.abstract_submodel("Doc", _fake_ctx(client))
+    abstract = result["abstract_submodel"]
+    id_shorts = {e["idShort"] for e in abstract["submodelElements"]}
+    assert id_shorts == {"Title", "Author"}
+    assert result["instance_count"] == 2
+
+
+def test_abstract_submodel_yaml_format():
+    client = MagicMock()
+    client.get_identifiables_by_type.return_value = [
+        {
+            "modelType": "Submodel",
+            "id": "urn:sm1",
+            "idShort": "Doc",
+            "kind": "Instance",
+            "submodelElements": [],
+        }
+    ]
+    result = mcp_server.abstract_submodel("Doc", _fake_ctx(client), output_format="yaml")
+    assert "yaml" in result
+    assert "abstract_submodel" not in result
+    assert "modelType: Submodel" in result["yaml"]
+
+
+def test_abstract_submodel_uses_semantic_id_when_uri():
+    client = MagicMock()
+    client.get_identifiables_by_type.return_value = []
+    with pytest.raises(ValueError):
+        mcp_server.abstract_submodel("https://example.com/mytype", _fake_ctx(client))
+    client.get_identifiables_by_type.assert_called_once_with(
+        "https://example.com/mytype", by_semantic_id=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require live Neo4j)
+# ---------------------------------------------------------------------------
+
+_EXAMPLE_SUBMODEL = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)),
+    "examples",
+    "submodels",
+)
+
+
+@pytest.mark.integration
+def test_count_stats_integration(aas_client):
+    result = mcp_server.count_stats(_fake_ctx(aas_client))
+    assert result == {"identifiables": 0, "referables": 0}
+
+
+@pytest.mark.integration
+def test_validate_constraints_empty_graph(aas_client):
+    result = mcp_server.validate_constraints(_fake_ctx(aas_client))
+    assert result["compliant"] is True
+    assert result["violations"] == []
+    assert len(result["checked_constraints"]) > 0
+
+
+@pytest.mark.integration
+def test_list_submodels_integration(aas_client):
+    result = mcp_server.list_submodels(_fake_ctx(aas_client))
+    assert result["total"] == 0
+    assert result["submodels"] == []
+
+
+@pytest.mark.integration
+def test_abstract_submodel_no_match_integration(aas_client):
+    with pytest.raises(ValueError, match="No Submodels found"):
+        mcp_server.abstract_submodel("NonExistentType", _fake_ctx(aas_client))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,15 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest>=7.0",
+    "testcontainers[neo4j]>=4.0",
 ]
+mcp = [
+    "mcp[cli]>=1.2",
+    "pyyaml>=6.0",
+]
+
+[project.scripts]
+aas4graph-mcp = "aas_mapping.mcp_server.server:main"
 
 [tool.setuptools.packages.find]
 include = ["aas_mapping*"]


### PR DESCRIPTION
This pull request introduces a new read-only Model Context Protocol (MCP) server to the `aas_mapping` package, enabling natural language querying, reading, and validation of Asset Administration Shell (AAS) data stored in Neo4j. It adds the `mcp_server` module, documents its usage, and updates the test suite for coverage. The server exposes a range of tools for interacting with the graph, including submodel abstraction and constraint validation, and is configurable via environment variables.

**Major new functionality: MCP server and tools**
- Added the `mcp_server` module, implementing a FastMCP-based server that exposes the Neo4j-backed AAS graph to MCP clients with a suite of read-only tools (e.g., submodel listing, querying, constraint validation, and submodel abstraction). (`aas_mapping/mcp_server/server.py`, `aas_mapping/mcp_server/__init__.py`, `aas_mapping/mcp_server/__main__.py`) [[1]](diffhunk://#diff-003c4bda5062d392494cfe7c5e61c5e8ff5762255bfb0cf0c36dc9216c016717R1-R333) [[2]](diffhunk://#diff-3e1ca808b9935ba9935fbe5516a4494f41c67caa071d504f6175a5853e22802aR1-R5) [[3]](diffhunk://#diff-c20337a81fadaca3cf0ec5838bd7a5e6ad0dfcb0980e3fc13ea3240513fec517R1-R6)
- Implemented submodel abstraction logic in `abstract.py`, allowing the server to build a structural union ("template") from all submodels of a given type. (`aas_mapping/mcp_server/abstract.py`)
- Added configuration management for Neo4j connection via environment variables in `config.py`. (`aas_mapping/mcp_server/config.py`)
- Extended the Neo4j client to support efficient retrieval of all submodels of a given type, supporting both `idShort` and `semanticId` matching. (`aas_mapping/aas_neo4j_adapter/aas_neo4j_client.py`)

**Documentation and developer experience**
- Updated `README.md` with a new section detailing the MCP server's purpose, installation, configuration, usage, available tools, and integration with Claude Desktop. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R286-R368) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25-R30)
- Expanded the test suite to include unit and integration tests for the MCP server, ensuring coverage of the new functionality. (`aas_mapping/test/test_mcp_server.py`, `README.md`)

**Testing improvements**
- Enhanced the Neo4j test fixture to use a disposable container by default, ensuring integration tests are isolated and safe, with clear instructions and fallbacks for custom configurations. (`aas_mapping/test/conftest.py`)