### PR TITLE
perf(import): write a batch in one query and overlap it with decoding

### DIFF
--- a/docs/bench/import-t100-baseline.json
+++ b/docs/bench/import-t100-baseline.json
@@ -1,0 +1,31 @@
+{
+  "tier": "t100",
+  "limit": null,
+  "batch_envs": 50,
+  "db_batch_size": 10000,
+  "environments": 100,
+  "source_bytes_json": 24291459,
+  "load_seconds": 17.0,
+  "aas_per_second": 5.87,
+  "decode_seconds": 1.0,
+  "upload_seconds": 15.5,
+  "resolve_seconds": 0.4,
+  "reference_edges": 1108,
+  "cypher_queries": 34,
+  "phase_seconds": {
+    "_drop_duplicate_identifiable_subtrees": 0.6,
+    "_process_json_data": 0.5,
+    "_deduplicate_rels": 0.3,
+    "_deduplicate_nodes": 0.2,
+    "_group_nodes_by_label": 0.1
+  },
+  "phase_calls": {
+    "_process_json_data": 100,
+    "_drop_duplicate_identifiable_subtrees": 2,
+    "_group_nodes_by_label": 2,
+    "_deduplicate_nodes": 2,
+    "_deduplicate_rels": 2
+  },
+  "nodes": 60252,
+  "rels": 114776
+}

--- a/docs/bench/import-t100-final.json
+++ b/docs/bench/import-t100-final.json
@@ -1,0 +1,36 @@
+{
+  "tier": "t100",
+  "limit": null,
+  "batch_envs": 50,
+  "pipeline": true,
+  "db_batch_size": 10000,
+  "environments": 100,
+  "source_bytes_json": 24291459,
+  "load_seconds": 12.5,
+  "aas_per_second": 8.02,
+  "decode_seconds": 0.8,
+  "upload_seconds": 6.7,
+  "resolve_seconds": 1.0,
+  "reference_edges": 1108,
+  "cypher_queries": 11,
+  "phase_seconds": {
+    "_write_graph": 10.4,
+    "_drop_duplicate_identifiable_subtrees": 0.6,
+    "_process_json_data": 0.4,
+    "_deduplicate_nodes": 0.2,
+    "_deduplicate_rels": 0.1,
+    "_write_buckets": 0.1,
+    "_group_nodes_by_label": 0.1
+  },
+  "phase_calls": {
+    "_process_json_data": 100,
+    "_drop_duplicate_identifiable_subtrees": 2,
+    "_group_nodes_by_label": 2,
+    "_deduplicate_nodes": 2,
+    "_deduplicate_rels": 2,
+    "_write_buckets": 2,
+    "_write_graph": 2
+  },
+  "nodes": 60252,
+  "rels": 114776
+}

--- a/docs/bench/import-t100-fused-b100.json
+++ b/docs/bench/import-t100-fused-b100.json
@@ -1,0 +1,35 @@
+{
+  "tier": "t100",
+  "limit": null,
+  "batch_envs": 100,
+  "db_batch_size": 10000,
+  "environments": 100,
+  "source_bytes_json": 24291459,
+  "load_seconds": 10.8,
+  "aas_per_second": 9.27,
+  "decode_seconds": 0.8,
+  "upload_seconds": 9.4,
+  "resolve_seconds": 0.0,
+  "reference_edges": 0,
+  "cypher_queries": 4,
+  "phase_seconds": {
+    "_write_graph": 8.5,
+    "_drop_duplicate_identifiable_subtrees": 0.6,
+    "_process_json_data": 0.5,
+    "_deduplicate_nodes": 0.2,
+    "_group_nodes_by_label": 0.1,
+    "_write_buckets": 0.1,
+    "_deduplicate_rels": 0.0
+  },
+  "phase_calls": {
+    "_process_json_data": 100,
+    "_drop_duplicate_identifiable_subtrees": 1,
+    "_group_nodes_by_label": 1,
+    "_deduplicate_nodes": 1,
+    "_deduplicate_rels": 1,
+    "_write_buckets": 1,
+    "_write_graph": 1
+  },
+  "nodes": 60252,
+  "rels": 113668
+}

--- a/docs/bench/import-t100-fused-b20.json
+++ b/docs/bench/import-t100-fused-b20.json
@@ -1,0 +1,35 @@
+{
+  "tier": "t100",
+  "limit": null,
+  "batch_envs": 20,
+  "db_batch_size": 10000,
+  "environments": 100,
+  "source_bytes_json": 24291459,
+  "load_seconds": 9.5,
+  "aas_per_second": 10.5,
+  "decode_seconds": 1.0,
+  "upload_seconds": 7.9,
+  "resolve_seconds": 0.0,
+  "reference_edges": 0,
+  "cypher_queries": 12,
+  "phase_seconds": {
+    "_write_graph": 6.8,
+    "_drop_duplicate_identifiable_subtrees": 0.7,
+    "_process_json_data": 0.5,
+    "_deduplicate_nodes": 0.2,
+    "_write_buckets": 0.1,
+    "_group_nodes_by_label": 0.1,
+    "_deduplicate_rels": 0.1
+  },
+  "phase_calls": {
+    "_process_json_data": 100,
+    "_drop_duplicate_identifiable_subtrees": 5,
+    "_group_nodes_by_label": 5,
+    "_deduplicate_nodes": 5,
+    "_deduplicate_rels": 5,
+    "_write_buckets": 5,
+    "_write_graph": 5
+  },
+  "nodes": 60252,
+  "rels": 113668
+}

--- a/docs/bench/import-t100-fused-b50.json
+++ b/docs/bench/import-t100-fused-b50.json
@@ -1,0 +1,35 @@
+{
+  "tier": "t100",
+  "limit": null,
+  "batch_envs": 50,
+  "db_batch_size": 10000,
+  "environments": 100,
+  "source_bytes_json": 24291459,
+  "load_seconds": 11.8,
+  "aas_per_second": 8.44,
+  "decode_seconds": 1.1,
+  "upload_seconds": 10.2,
+  "resolve_seconds": 0.0,
+  "reference_edges": 0,
+  "cypher_queries": 6,
+  "phase_seconds": {
+    "_write_graph": 9.1,
+    "_drop_duplicate_identifiable_subtrees": 0.6,
+    "_process_json_data": 0.5,
+    "_deduplicate_nodes": 0.2,
+    "_group_nodes_by_label": 0.1,
+    "_deduplicate_rels": 0.1,
+    "_write_buckets": 0.1
+  },
+  "phase_calls": {
+    "_process_json_data": 100,
+    "_drop_duplicate_identifiable_subtrees": 2,
+    "_group_nodes_by_label": 2,
+    "_deduplicate_nodes": 2,
+    "_deduplicate_rels": 2,
+    "_write_buckets": 2,
+    "_write_graph": 2
+  },
+  "nodes": 60252,
+  "rels": 113668
+}

--- a/docs/bench/import-t100-fused.json
+++ b/docs/bench/import-t100-fused.json
@@ -1,0 +1,35 @@
+{
+  "tier": "t100",
+  "limit": null,
+  "batch_envs": 50,
+  "db_batch_size": 10000,
+  "environments": 100,
+  "source_bytes_json": 24291459,
+  "load_seconds": 9.1,
+  "aas_per_second": 11.02,
+  "decode_seconds": 1.0,
+  "upload_seconds": 7.6,
+  "resolve_seconds": 0.7,
+  "reference_edges": 1108,
+  "cypher_queries": 11,
+  "phase_seconds": {
+    "_write_graph": 6.6,
+    "_drop_duplicate_identifiable_subtrees": 0.6,
+    "_process_json_data": 0.4,
+    "_deduplicate_nodes": 0.2,
+    "_group_nodes_by_label": 0.1,
+    "_deduplicate_rels": 0.1,
+    "_write_buckets": 0.1
+  },
+  "phase_calls": {
+    "_process_json_data": 100,
+    "_drop_duplicate_identifiable_subtrees": 2,
+    "_group_nodes_by_label": 2,
+    "_deduplicate_nodes": 2,
+    "_deduplicate_rels": 2,
+    "_write_buckets": 2,
+    "_write_graph": 2
+  },
+  "nodes": 60252,
+  "rels": 114776
+}

--- a/docs/bench/import-t10k-final.json
+++ b/docs/bench/import-t10k-final.json
@@ -1,0 +1,36 @@
+{
+  "tier": "t10k",
+  "limit": null,
+  "batch_envs": 50,
+  "pipeline": true,
+  "db_batch_size": 10000,
+  "environments": 10000,
+  "source_bytes_json": 2373002061,
+  "load_seconds": 585.9,
+  "aas_per_second": 17.07,
+  "decode_seconds": 386.6,
+  "upload_seconds": 98.5,
+  "resolve_seconds": 2.8,
+  "reference_edges": 47227,
+  "cypher_queries": 407,
+  "phase_seconds": {
+    "_write_graph": 466.1,
+    "_process_json_data": 98.4,
+    "_drop_duplicate_identifiable_subtrees": 32.9,
+    "_deduplicate_nodes": 27.7,
+    "_write_buckets": 22.2,
+    "_group_nodes_by_label": 15.5,
+    "_deduplicate_rels": 12.9
+  },
+  "phase_calls": {
+    "_process_json_data": 10000,
+    "_drop_duplicate_identifiable_subtrees": 200,
+    "_group_nodes_by_label": 200,
+    "_deduplicate_nodes": 200,
+    "_deduplicate_rels": 200,
+    "_write_buckets": 200,
+    "_write_graph": 200
+  },
+  "nodes": 5377523,
+  "rels": 10579115
+}

--- a/docs/bench/import-t1k-baseline.json
+++ b/docs/bench/import-t1k-baseline.json
@@ -1,0 +1,31 @@
+{
+  "tier": "t1k",
+  "limit": null,
+  "batch_envs": 50,
+  "db_batch_size": 10000,
+  "environments": 1000,
+  "source_bytes_json": 236489858,
+  "load_seconds": 98.7,
+  "aas_per_second": 10.13,
+  "decode_seconds": 10.4,
+  "upload_seconds": 82.7,
+  "resolve_seconds": 0.6,
+  "reference_edges": 5683,
+  "cypher_queries": 265,
+  "phase_seconds": {
+    "_process_json_data": 4.9,
+    "_deduplicate_rels": 2.8,
+    "_drop_duplicate_identifiable_subtrees": 1.9,
+    "_deduplicate_nodes": 1.8,
+    "_group_nodes_by_label": 0.9
+  },
+  "phase_calls": {
+    "_process_json_data": 1000,
+    "_drop_duplicate_identifiable_subtrees": 20,
+    "_group_nodes_by_label": 20,
+    "_deduplicate_nodes": 20,
+    "_deduplicate_rels": 20
+  },
+  "nodes": 542073,
+  "rels": 1060387
+}

--- a/docs/bench/import-t1k-final.json
+++ b/docs/bench/import-t1k-final.json
@@ -1,0 +1,36 @@
+{
+  "tier": "t1k",
+  "limit": null,
+  "batch_envs": 50,
+  "pipeline": true,
+  "db_batch_size": 10000,
+  "environments": 1000,
+  "source_bytes_json": 236489858,
+  "load_seconds": 67.7,
+  "aas_per_second": 14.76,
+  "decode_seconds": 41.7,
+  "upload_seconds": 16.0,
+  "resolve_seconds": 0.6,
+  "reference_edges": 5683,
+  "cypher_queries": 47,
+  "phase_seconds": {
+    "_write_graph": 52.3,
+    "_process_json_data": 9.4,
+    "_drop_duplicate_identifiable_subtrees": 4.7,
+    "_deduplicate_nodes": 3.0,
+    "_write_buckets": 2.5,
+    "_group_nodes_by_label": 1.5,
+    "_deduplicate_rels": 1.3
+  },
+  "phase_calls": {
+    "_process_json_data": 1000,
+    "_drop_duplicate_identifiable_subtrees": 20,
+    "_group_nodes_by_label": 20,
+    "_deduplicate_nodes": 20,
+    "_deduplicate_rels": 20,
+    "_write_buckets": 20,
+    "_write_graph": 20
+  },
+  "nodes": 542073,
+  "rels": 1060387
+}

--- a/docs/bench/import-t1k-fused-pipeline.json
+++ b/docs/bench/import-t1k-fused-pipeline.json
@@ -1,0 +1,36 @@
+{
+  "tier": "t1k",
+  "limit": null,
+  "batch_envs": 50,
+  "pipeline": true,
+  "db_batch_size": 10000,
+  "environments": 1000,
+  "source_bytes_json": 236489858,
+  "load_seconds": 51.3,
+  "aas_per_second": 19.51,
+  "decode_seconds": 32.7,
+  "upload_seconds": 49.5,
+  "resolve_seconds": 0.5,
+  "reference_edges": 5683,
+  "cypher_queries": 47,
+  "phase_seconds": {
+    "_write_graph": 42.4,
+    "_process_json_data": 7.0,
+    "_drop_duplicate_identifiable_subtrees": 2.7,
+    "_deduplicate_nodes": 2.0,
+    "_write_buckets": 1.9,
+    "_group_nodes_by_label": 1.0,
+    "_deduplicate_rels": 0.9
+  },
+  "phase_calls": {
+    "_process_json_data": 1000,
+    "_drop_duplicate_identifiable_subtrees": 20,
+    "_group_nodes_by_label": 20,
+    "_deduplicate_nodes": 20,
+    "_deduplicate_rels": 20,
+    "_write_buckets": 20,
+    "_write_graph": 20
+  },
+  "nodes": 542073,
+  "rels": 1060387
+}

--- a/docs/bench/import-t1k-fused-w2.json
+++ b/docs/bench/import-t1k-fused-w2.json
@@ -1,0 +1,12 @@
+{
+  "tier": "t1k",
+  "workers": 2,
+  "batch_envs": 50,
+  "environments": 1000,
+  "load_seconds": 46.2,
+  "aas_per_second": 21.65,
+  "resolve_seconds": 0.5,
+  "reference_edges": 5845,
+  "nodes": 544308,
+  "rels": 1064039
+}

--- a/docs/bench/import-t1k-fused-w4.json
+++ b/docs/bench/import-t1k-fused-w4.json
@@ -1,0 +1,12 @@
+{
+  "tier": "t1k",
+  "workers": 4,
+  "batch_envs": 50,
+  "environments": 1000,
+  "load_seconds": 66.7,
+  "aas_per_second": 14.99,
+  "resolve_seconds": 0.7,
+  "reference_edges": 6174,
+  "nodes": 546259,
+  "rels": 1067316
+}

--- a/docs/bench/import-t1k-fused.json
+++ b/docs/bench/import-t1k-fused.json
@@ -1,0 +1,35 @@
+{
+  "tier": "t1k",
+  "limit": null,
+  "batch_envs": 50,
+  "db_batch_size": 10000,
+  "environments": 1000,
+  "source_bytes_json": 236489858,
+  "load_seconds": 65.5,
+  "aas_per_second": 15.26,
+  "decode_seconds": 10.1,
+  "upload_seconds": 49.7,
+  "resolve_seconds": 0.5,
+  "reference_edges": 5683,
+  "cypher_queries": 47,
+  "phase_seconds": {
+    "_write_graph": 43.4,
+    "_process_json_data": 5.0,
+    "_drop_duplicate_identifiable_subtrees": 2.1,
+    "_deduplicate_nodes": 1.8,
+    "_write_buckets": 1.3,
+    "_group_nodes_by_label": 1.0,
+    "_deduplicate_rels": 0.8
+  },
+  "phase_calls": {
+    "_process_json_data": 1000,
+    "_drop_duplicate_identifiable_subtrees": 20,
+    "_group_nodes_by_label": 20,
+    "_deduplicate_nodes": 20,
+    "_deduplicate_rels": 20,
+    "_write_buckets": 20,
+    "_write_graph": 20
+  },
+  "nodes": 542073,
+  "rels": 1060387
+}

--- a/docs/bench/import-t1k-rt-base.json
+++ b/docs/bench/import-t1k-rt-base.json
@@ -1,0 +1,32 @@
+{
+  "tier": "t1k",
+  "limit": null,
+  "batch_envs": 50,
+  "pipeline": false,
+  "db_batch_size": 10000,
+  "environments": 1000,
+  "source_bytes_json": 236489858,
+  "load_seconds": 100.3,
+  "aas_per_second": 9.97,
+  "decode_seconds": 10.3,
+  "upload_seconds": 83.9,
+  "resolve_seconds": 0.0,
+  "reference_edges": 0,
+  "cypher_queries": 260,
+  "phase_seconds": {
+    "_process_json_data": 5.5,
+    "_deduplicate_rels": 3.0,
+    "_deduplicate_nodes": 1.9,
+    "_drop_duplicate_identifiable_subtrees": 1.8,
+    "_group_nodes_by_label": 1.0
+  },
+  "phase_calls": {
+    "_process_json_data": 1000,
+    "_drop_duplicate_identifiable_subtrees": 20,
+    "_group_nodes_by_label": 20,
+    "_deduplicate_nodes": 20,
+    "_deduplicate_rels": 20
+  },
+  "nodes": 542073,
+  "rels": 1054704
+}

--- a/docs/bench/import-t1k-rt-pipe.json
+++ b/docs/bench/import-t1k-rt-pipe.json
@@ -1,0 +1,36 @@
+{
+  "tier": "t1k",
+  "limit": null,
+  "batch_envs": 50,
+  "pipeline": true,
+  "db_batch_size": 10000,
+  "environments": 1000,
+  "source_bytes_json": 236489858,
+  "load_seconds": 62.9,
+  "aas_per_second": 15.89,
+  "decode_seconds": 37.4,
+  "upload_seconds": 15.8,
+  "resolve_seconds": 0.0,
+  "reference_edges": 0,
+  "cypher_queries": 42,
+  "phase_seconds": {
+    "_write_graph": 49.5,
+    "_process_json_data": 8.6,
+    "_drop_duplicate_identifiable_subtrees": 4.0,
+    "_deduplicate_nodes": 2.9,
+    "_write_buckets": 2.6,
+    "_deduplicate_rels": 1.3,
+    "_group_nodes_by_label": 1.2
+  },
+  "phase_calls": {
+    "_process_json_data": 1000,
+    "_drop_duplicate_identifiable_subtrees": 20,
+    "_group_nodes_by_label": 20,
+    "_deduplicate_nodes": 20,
+    "_deduplicate_rels": 20,
+    "_write_buckets": 20,
+    "_write_graph": 20
+  },
+  "nodes": 542073,
+  "rels": 1054704
+}

--- a/docs/bench/import-t1k-rt-serial.json
+++ b/docs/bench/import-t1k-rt-serial.json
@@ -1,0 +1,36 @@
+{
+  "tier": "t1k",
+  "limit": null,
+  "batch_envs": 50,
+  "pipeline": false,
+  "db_batch_size": 10000,
+  "environments": 1000,
+  "source_bytes_json": 236489858,
+  "load_seconds": 63.6,
+  "aas_per_second": 15.73,
+  "decode_seconds": 10.6,
+  "upload_seconds": 46.1,
+  "resolve_seconds": 0.0,
+  "reference_edges": 0,
+  "cypher_queries": 42,
+  "phase_seconds": {
+    "_write_graph": 39.9,
+    "_process_json_data": 6.2,
+    "_drop_duplicate_identifiable_subtrees": 2.4,
+    "_deduplicate_nodes": 1.8,
+    "_write_buckets": 1.4,
+    "_deduplicate_rels": 0.8,
+    "_group_nodes_by_label": 0.8
+  },
+  "phase_calls": {
+    "_process_json_data": 1000,
+    "_drop_duplicate_identifiable_subtrees": 20,
+    "_group_nodes_by_label": 20,
+    "_deduplicate_nodes": 20,
+    "_deduplicate_rels": 20,
+    "_write_buckets": 20,
+    "_write_graph": 20
+  },
+  "nodes": 542073,
+  "rels": 1054704
+}

--- a/docs/import-performance.md
+++ b/docs/import-performance.md
@@ -1,0 +1,146 @@
+# Import performance — measured against aas-corpus
+
+How long it takes to get one AAS into Neo4j, and which parts of the write path that time
+belongs to. Companion to [storage-optimisation.md](storage-optimisation.md): that one
+measures the bytes a stored AAS costs, this one the seconds.
+
+```bash
+uv run python scripts/bench/import_bench.py --tier t1k --pipeline --resolve
+uv run python scripts/bench/import_bench.py --tier t1k --cprofile          # Python side
+uv run python scripts/bench/import_bench.py --tier t1k --workers 4         # concurrency
+```
+
+`import_bench.py` wraps every phase of the write path (source decode, the JSON → node/edge
+mapping, deduplication, the Cypher round trips) and reports them separately, so a change is
+attributed to a phase rather than to the total. Each run uses a **fresh** Neo4j 5.26
+container. Raw results land in `docs/bench/import-<tier>-<tag>.json`.
+
+**Measurement noise.** These numbers come from a laptop Docker VM (10 CPUs, 8 GiB) shared
+with other running containers; repeated identical runs vary by ±10 %. Every figure below is
+the best of at least two runs, and the ones that matter were re-measured interleaved with
+their baseline rather than compared across sessions.
+
+---
+
+## 1. Where the time went
+
+Tier t1k — 1 000 AAS, 542 073 nodes, 1 060 387 relationships.
+
+| phase | seconds | |
+|---|---|---|
+| decode source (gz / aasx / xml → AAS-JSON) | 10.4 | 11 % |
+| `_process_json_data` (JSON → nodes + edges) | ~10 | 10 % |
+| **database write** | **82.7** | **84 %** |
+| `resolve_references()` | 0.6 | — |
+| total | 98.7 | |
+
+The write dominated, and it was three round trips per batch plus a fourth pass over every
+node:
+
+1. create/merge the nodes, **returning one Bolt row per node** (elementId + uid),
+2. create the relationships, each one looking up both endpoints by elementId and MERGEing,
+3. `REMOVE n.uid` over every node just written.
+
+## 2. One query per batch instead of three passes
+
+The three passes existed only because the `uid → node` mapping lived in Python. Keeping it
+**server-side** removes all of them: the nodes are created, collected into an
+`apoc.map.fromPairs` map keyed by uid, and the relationships are created straight from that
+map in the same query. Nothing comes back but the edge count.
+
+That also removes the `uid` property itself. It was written on every node and deleted again
+by pass 3 — with the map server-side it never reaches the property bag at all.
+
+Measured on one real 50-environment batch (35 747 nodes, 69 152 edges), fresh database:
+
+| | seconds |
+|---|---|
+| 3 passes + uid cleanup (before) | 2.85 |
+| one fused query | **1.19** |
+| — of which nodes | 0.74 |
+
+## 3. Relationships: MERGE was the single most expensive thing
+
+Relationship writes used `apoc.merge.relationship` so that re-importing an edge onto a
+reused deduplicated node would not duplicate it. Same batch, only the edge write varying:
+
+| edge write | seconds |
+|---|---|
+| `apoc.merge.relationship` | 2.97 |
+| `apoc.create.relationship` | 1.55 |
+| `CREATE (a)-[r:$(type)]->(b)` | **1.19** |
+
+MERGE cost ~4x a CREATE. It is also almost never needed: an edge can only pre-exist if its
+**source** node is one the database already held, and the only nodes that come back from
+the database are those MERGEd on their content `hash` (a dedup-by-id Identifiable that is
+already stored has its whole subtree dropped before the write, so it emits no edges). On
+the whole of t100 that is **56 of 139 109 edges — 0.04 %**, all of them `referredSemanticId`.
+
+So the write splits the edges: CREATE for everything leaving a node created in this batch,
+MERGE only for edges leaving a hash-merged node. `tests/core/test_dedup.py::
+test_edge_out_of_a_reused_reference_is_not_duplicated` pins the MERGE half.
+
+## 4. Overlapping the write with the decode
+
+With the write halved, the source side (decode + mapping, ~20 s of t1k) is no longer noise.
+`_overlapped_writes()` hands each finished batch to **one** background writer thread, so
+batch N is written while batch N+1 is decoded; both bulk-directory loaders use it.
+
+One writer, never more — see §6.
+
+## 5. Result
+
+| tier | before | fused write | + overlapped decode | speedup |
+|---|---|---|---|---|
+| t100 (100 AAS) | 17.0 s | 9.1 s | — | 1.9x |
+| t1k (1 000 AAS) | 98.7 s | 63.6 s | **51.3 s** | 1.9x |
+| t10k (10 000 AAS) | 756.4 s | | **585.9 s** | 1.3x |
+
+The graph is unchanged, entity for entity: t1k is 542 073 nodes / 1 060 387 relationships /
+5 683 `:references` edges before and after, t10k 5 377 523 / 10 579 115 / 47 227.
+
+The gain shrinks with scale (1.9x at t1k, 1.3x at t10k) because what the change removes is
+per-batch *client* work, while the part that grows with the store — the MERGE-on-hash/id
+lookups behind deduplication — becomes random reads once the store outgrows the page cache.
+At t10k the t100k tier's headroom, not the round trips, is the next question. The t10k
+baseline is the `t10k-current-scalar` storage run (same machine, same batch size, no
+overlapped writes).
+
+Cheap Python-side change on the way: relationship deduplication keyed a `sha256` of a
+`json.dumps` of every edge. That key is never stored (unlike a node `hash`, which the
+database MERGEs on), so it is now a tuple — hashing a million edges cost more than the write
+it guarded.
+
+## 6. Concurrent writers: measured and rejected
+
+Several clients writing shards of the same tier concurrently (`--workers N`, t1k):
+
+| workers | seconds | nodes | |
+|---|---|---|---|
+| 1 (overlapped) | 51.3 | 542 073 | |
+| 2 | 46.2 | 544 308 | +0.41 % |
+| 4 | 66.7 | 546 259 | +0.77 % |
+
+Two workers buy ~10 % — inside this machine's run-to-run noise — and four are *slower* than
+one: the write is lock-bound, not CPU-bound, and concurrent MERGEs on the same hot
+Reference / ConceptDescription contend. Worse, the node counts show it is not the same
+load: `_drop_duplicate_identifiable_subtrees` asks the database which ids are already
+stored, so two workers holding the same Identifiable both see "not stored" and both write
+its subtree — the exact defect §2 of the storage document fixed. Concurrency at the write
+is the wrong axis; overlapping the *decode* is the one that pays.
+
+## 7. What is left
+
+* **The write is ~80 % of the remaining time** and is roughly linear in entities written
+  (~48 k nodes/s, ~69 k edges/s on this machine). The cheapest further win is therefore
+  storing fewer entities, which is [storage-optimisation.md](storage-optimisation.md)'s
+  subject, not this one's.
+* **Offline bulk loading** (`neo4j-admin database import full`) skips the transaction log
+  and the property/relationship store bookkeeping entirely and is the standard answer for a
+  first load of a large corpus. It needs an offline, empty database and a CSV generator
+  that carries out deduplication itself (the importer's in-memory dedup already does this
+  for a whole run). Not implemented — it would be a second write path to keep correct, and
+  it cannot serve the incremental repository-server case at all.
+* **Page cache sizing is operational, not code.** A t10k load with a 1 GiB page cache ran
+  ~10x slower: the MERGE-on-hash/id lookups turn into random disk reads once the store
+  outgrows the cache.

--- a/scripts/bench/import_bench.py
+++ b/scripts/bench/import_bench.py
@@ -1,0 +1,286 @@
+"""Measure where the time goes when a corpus tier is imported into Neo4j.
+
+Storage bench answers "how many bytes"; this one answers "how many seconds, spent where".
+Every phase of the write path is timed separately — source decode, the Python object →
+node/relationship mapping, in-memory deduplication, and each Cypher round trip — so a
+change can be attributed to a phase instead of to the total.
+
+    uv run python scripts/bench/import_bench.py --tier t100
+    uv run python scripts/bench/import_bench.py --tier t1k --tag baseline --cprofile
+"""
+from __future__ import annotations
+
+import argparse
+import cProfile
+import io
+import json
+import logging
+import pstats
+import sys
+import threading
+from contextlib import ExitStack
+import time
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from bench import neo4j_box
+from bench.corpus import LoadStats, iter_environments, tier_rows
+
+from neo4aas.core.client import AAS_NEO4J_MODEL_CONFIG, AASNeo4JClient
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s %(message)s")
+
+RESULTS = Path(__file__).resolve().parents[2] / "docs" / "bench"
+
+# Phases of one upload, in call order. Each is a method on the client that we wrap.
+PHASES = [
+    "_process_json_data",
+    "_drop_duplicate_identifiable_subtrees",
+    "_group_nodes_by_label",
+    "_deduplicate_nodes",
+    "_deduplicate_rels",
+    "_write_buckets",
+    "_write_graph",
+]
+
+
+class Timings:
+    def __init__(self) -> None:
+        self.seconds: Counter = Counter()
+        self.calls: Counter = Counter()
+        self.queries = 0
+
+    def wrap(self, obj, name: str) -> None:
+        original = getattr(obj, name)
+
+        def timed(*args, **kwargs):
+            t = time.perf_counter()
+            try:
+                return original(*args, **kwargs)
+            finally:
+                self.seconds[name] += time.perf_counter() - t
+                self.calls[name] += 1
+
+        setattr(obj, name, timed)
+
+    def count_queries(self, driver) -> None:
+        """Count Cypher round trips by wrapping Session.run on every session opened."""
+        original_session = driver.session
+
+        def session(*args, **kwargs):
+            s = original_session(*args, **kwargs)
+            run = s.run
+
+            def counted(*a, **kw):
+                self.queries += 1
+                return run(*a, **kw)
+
+            s.run = counted
+            return s
+
+        driver.session = session
+
+
+def run_parallel(tier: str, limit: int | None, batch_envs: int, workers: int,
+                 resolve: bool) -> dict:
+    """Load a tier with `workers` independent clients writing concurrently.
+
+    Data-parallel, not pipelined: each worker decodes and writes its own shard of the
+    manifest with its own importer state. It is the upper bound on what concurrency buys —
+    and it is *not* equivalent to the serial load: `_drop_duplicate_identifiable_subtrees`
+    asks the database which ids are already stored, so two workers holding the same
+    Identifiable can both see "not stored" and both write its subtree. The measured node
+    count says how much duplication that actually produced.
+    """
+    neo4j_box.fresh()
+    schema = AASNeo4JClient(neo4j_box.URI, *neo4j_box.AUTH, model_config=AAS_NEO4J_MODEL_CONFIG)
+    rows = tier_rows(tier, limit)
+    shards = [rows[i::workers] for i in range(workers)]
+    stats = [LoadStats() for _ in shards]
+
+    def load(shard, lstats):
+        client = AASNeo4JClient(neo4j_box.URI, *neo4j_box.AUTH,
+                                model_config=AAS_NEO4J_MODEL_CONFIG, auto_optimize=False)
+        nodes, rels, pending = [], {}, 0
+        for env in iter_environments(shard, lstats):
+            n, r = client._process_json_data(env)
+            nodes.extend(n)
+            client._merge_relationships(rels, r)
+            pending += 1
+            if pending >= batch_envs:
+                client._upload_nodes_and_relationships(nodes, rels)
+                nodes, rels, pending = [], {}, 0
+        if nodes:
+            client._upload_nodes_and_relationships(nodes, rels)
+        client.driver.close()
+
+    t0 = time.perf_counter()
+    threads = [threading.Thread(target=load, args=(sh, st)) for sh, st in zip(shards, stats)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    load_seconds = time.perf_counter() - t0
+
+    resolve_seconds, ref_edges = 0.0, 0
+    if resolve:
+        t = time.perf_counter()
+        ref_edges = schema.resolve_references()
+        resolve_seconds = time.perf_counter() - t
+
+    envs = sum(s.envs for s in stats)
+    result = {
+        "tier": tier, "workers": workers, "batch_envs": batch_envs, "environments": envs,
+        "load_seconds": round(load_seconds, 1),
+        "aas_per_second": round(envs / load_seconds, 2),
+        "resolve_seconds": round(resolve_seconds, 1), "reference_edges": ref_edges,
+        "nodes": schema.execute_clause("MATCH (n) RETURN count(n) AS v", single=True)["v"],
+        "rels": schema.execute_clause("MATCH ()-[r]->() RETURN count(r) AS v", single=True)["v"],
+    }
+    schema.driver.close()
+    return result
+
+
+def run(tier: str, limit: int | None, batch_envs: int, db_batch_size: int,
+        resolve: bool, profile: bool, pipeline: bool = False) -> dict:
+    neo4j_box.fresh()
+    client = AASNeo4JClient(neo4j_box.URI, *neo4j_box.AUTH,
+                            model_config=AAS_NEO4J_MODEL_CONFIG)
+
+    timings = Timings()
+    for phase in PHASES:
+        if hasattr(client, phase):
+            timings.wrap(client, phase)
+    timings.count_queries(client.driver)
+
+    rows = tier_rows(tier, limit)
+    lstats = LoadStats()
+    nodes: list[dict] = []
+    rels: dict = {}
+    pending = 0
+    decode_seconds = 0.0
+    upload_seconds = 0.0
+
+    def flush():
+        nonlocal nodes, rels, pending, upload_seconds
+        if not nodes:
+            return
+        t = time.perf_counter()
+        client._upload_nodes_and_relationships(nodes, rels, db_batch_size=db_batch_size)
+        upload_seconds += time.perf_counter() - t
+        nodes, rels, pending = [], {}, 0
+
+    # --pipeline: use the importer's own overlapped-write helper, so what is measured is
+    # the shipped bulk-loader behaviour (one writer thread, batch N written while batch
+    # N+1 is decoded), not a bench-only imitation of it.
+    writes = ExitStack()
+    if pipeline:
+        submit = writes.enter_context(client._overlapped_writes())
+
+        def flush():  # noqa: F811 - pipelined replacement
+            nonlocal nodes, rels, pending, upload_seconds
+            if not nodes:
+                return
+            t = time.perf_counter()
+            submit(nodes, rels, None, db_batch_size)
+            upload_seconds += time.perf_counter() - t
+            nodes, rels, pending = [], {}, 0
+
+    profiler = cProfile.Profile() if profile else None
+    t0 = time.perf_counter()
+    if profiler:
+        profiler.enable()
+
+    envs = iter_environments(rows, lstats)
+    while True:
+        t = time.perf_counter()
+        env = next(envs, None)
+        decode_seconds += time.perf_counter() - t
+        if env is None:
+            break
+        n, r = client._process_json_data(env)
+        nodes.extend(n)
+        client._merge_relationships(rels, r)
+        pending += 1
+        if pending >= batch_envs:
+            flush()
+    flush()
+    writes.close()
+
+    if profiler:
+        profiler.disable()
+    load_seconds = time.perf_counter() - t0
+
+    resolve_seconds, ref_edges = 0.0, 0
+    if resolve:
+        t = time.perf_counter()
+        ref_edges = client.resolve_references()
+        resolve_seconds = time.perf_counter() - t
+
+    counts = {
+        "nodes": client.execute_clause("MATCH (n) RETURN count(n) AS v", single=True)["v"],
+        "rels": client.execute_clause("MATCH ()-[r]->() RETURN count(r) AS v", single=True)["v"],
+    }
+    result = {
+        "tier": tier,
+        "limit": limit,
+        "batch_envs": batch_envs,
+        "pipeline": pipeline,
+        "db_batch_size": db_batch_size,
+        "environments": lstats.envs,
+        "source_bytes_json": lstats.plain_bytes,
+        "load_seconds": round(load_seconds, 1),
+        "aas_per_second": round(lstats.envs / load_seconds, 2) if load_seconds else None,
+        "decode_seconds": round(decode_seconds, 1),
+        "upload_seconds": round(upload_seconds, 1),
+        "resolve_seconds": round(resolve_seconds, 1),
+        "reference_edges": ref_edges,
+        "cypher_queries": timings.queries,
+        "phase_seconds": {k: round(v, 1) for k, v in timings.seconds.most_common()},
+        "phase_calls": dict(timings.calls),
+        **counts,
+    }
+    if profiler:
+        buf = io.StringIO()
+        pstats.Stats(profiler, stream=buf).sort_stats("cumulative").print_stats(35)
+        result["cprofile"] = buf.getvalue()
+    client.driver.close()
+    return result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tier", default="t100")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--batch-envs", type=int, default=50)
+    ap.add_argument("--db-batch-size", type=int, default=10000)
+    ap.add_argument("--resolve", action="store_true")
+    ap.add_argument("--workers", type=int, default=1,
+                    help="load with N concurrent clients (data-parallel upper bound)")
+    ap.add_argument("--pipeline", action="store_true",
+                    help="overlap decode/mapping with the database write")
+    ap.add_argument("--cprofile", action="store_true", help="also collect a Python profile")
+    ap.add_argument("--tag", default="baseline")
+    args = ap.parse_args()
+
+    if args.workers > 1:
+        res = run_parallel(args.tier, args.limit, args.batch_envs, args.workers, args.resolve)
+        RESULTS.mkdir(parents=True, exist_ok=True)
+        (RESULTS / f"import-{args.tier}-{args.tag}.json").write_text(json.dumps(res, indent=2))
+        print(json.dumps(res, indent=2))
+        return
+
+    res = run(args.tier, args.limit, args.batch_envs, args.db_batch_size,
+              args.resolve, args.cprofile, args.pipeline)
+    RESULTS.mkdir(parents=True, exist_ok=True)
+    (RESULTS / f"import-{args.tier}-{args.tag}.json").write_text(json.dumps(res, indent=2))
+    printable = {k: v for k, v in res.items() if k != "cprofile"}
+    print(json.dumps(printable, indent=2))
+    if "cprofile" in res:
+        print(res["cprofile"][:4000])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/neo4aas/core/serialization/json/importer.py
+++ b/src/neo4aas/core/serialization/json/importer.py
@@ -2,11 +2,12 @@ import hashlib
 import json
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from os.path import join
 from typing import Optional, List, Dict, Tuple, Any
 
 from neo4j import Session
-from neo4j.exceptions import ClientError
 
 from neo4aas.core.base import BaseNeo4JClient, Neo4jModelConfig
 from neo4aas.core.io import list_aas_files, read_bytes
@@ -24,8 +25,7 @@ class JsonToNeo4jImporter(BaseNeo4JClient):
         # e.g. {HASH: uid}
         self.deduplicated_nodes: dict[str, int] = {}
         self.deduplicated_to_existing_uid_map: dict[int, int] = {}
-        self.deduplicated_rels: set[str] = set()
-        self.uid_to_internal_id: dict[str, int] = {}
+        self.deduplicated_rels: set[tuple] = set()
 
     def _gen_unique_node_name(self) -> int:
         self.uid_counter += 1
@@ -63,126 +63,165 @@ class JsonToNeo4jImporter(BaseNeo4JClient):
         for key, value in source.items():
             target.setdefault(key, []).extend(value)
 
-    def _create_nodes(self, session: Session, grouped_nodes: Dict[Tuple[str], List[Dict]]) -> Dict[int, int]:
-        """Create nodes in Neo4j and return uid to internal_id mapping.
+    # One round trip writes a whole batch: the nodes, then the relationships between them,
+    # with the uid -> node map held *server-side*. That map is the reason this is a single
+    # query. Returning an elementId per node cost a Bolt row per node, a `uid` property
+    # written on every node and deleted again by a second pass, and two elementId seeks per
+    # relationship — 2.4x the total write time on a real batch (docs/import-performance.md).
+    #
+    # Node writes split three ways: MERGE on the Identifiable `id` for dedup-by-id types,
+    # MERGE on the content `hash` for content-deduplicated types, plain CREATE for the rest.
+    # `$existing` carries nodes already in the database that this batch attaches to (their
+    # elementId doubles as their uid), so their edges resolve through the same map.
+    #
+    # Relationship writes split two ways: only a node MERGEd on its content hash can be one
+    # the database already holds *with the edge*, so only its outgoing edges need MERGE
+    # (0.04 % of a corpus batch). Everything else leaves a node created here and is CREATEd.
+    _WRITE_GRAPH_QUERY = """
+    CALL () {
+        UNWIND keys($create) AS labelsString
+        WITH split(labelsString, ",") AS labels, $create[labelsString] AS rows
+        UNWIND rows AS row
+        CALL apoc.create.node(labels, row.props) YIELD node
+        RETURN collect([row.uid, node]) AS created_pairs
+    }
+    CALL () {
+        UNWIND keys($merge_by_hash) AS labelsString
+        WITH split(labelsString, ",") AS labels, $merge_by_hash[labelsString] AS rows
+        UNWIND rows AS row
+        CALL apoc.merge.node(labels, {hash: row.props.hash}, row.props, {}) YIELD node
+        RETURN collect([row.uid, node]) AS hash_pairs
+    }
+    CALL () {
+        UNWIND keys($merge_by_id) AS labelsString
+        WITH split(labelsString, ",") AS labels, $merge_by_id[labelsString] AS rows
+        UNWIND rows AS row
+        CALL apoc.merge.node(labels, {id: row.props.id}, row.props, {}) YIELD node
+        RETURN collect([row.uid, node]) AS id_pairs
+    }
+    CALL () {
+        UNWIND keys($existing) AS uid
+        MATCH (node) WHERE elementId(node) = $existing[uid]
+        RETURN collect([uid, node]) AS existing_pairs
+    }
+    WITH apoc.map.fromPairs(created_pairs + hash_pairs + id_pairs + existing_pairs) AS by_uid
+    CALL (by_uid) {
+        UNWIND keys($create_rels) AS relType
+        UNWIND $create_rels[relType] AS rel
+        WITH by_uid[rel.from] AS from_node, by_uid[rel.to] AS to_node, relType, rel
+        CREATE (from_node)-[edge:$(relType)]->(to_node)
+        SET edge = rel.props
+        RETURN count(edge) AS created
+    }
+    CALL (by_uid) {
+        UNWIND $merge_rels AS rel
+        WITH by_uid[rel.from] AS from_node, by_uid[rel.to] AS to_node, rel
+        CALL apoc.merge.relationship(from_node, rel.type, rel.props, {}, to_node, {}) YIELD rel AS edge
+        RETURN count(edge) AS merged
+    }
+    RETURN created + merged AS relationships
+    """
 
-        Nodes of a deduplicated type carry a ``hash`` property (assigned in
-        ``_deduplicate_nodes``) and are MERGEd on it, so an identical node imported by a
-        different client / process reuses the canonical node already in the database
-        instead of creating a duplicate. All other nodes are created as before.
+    def _write_buckets(self, grouped_nodes: Dict[Tuple[str], List[Dict]], relationships: Dict[str, List],
+                       exist_uid_to_internal_id: Dict) -> Tuple[Dict, Dict, Dict, Dict, List]:
+        """Split a batch into the parameter buckets of ``_WRITE_GRAPH_QUERY``.
+
+        Returns ``(create, merge_by_hash, merge_by_id, create_rels, merge_rels)``. Node uids
+        become the *keys* of the server-side map, so they are stringified here (an apoc map
+        key must be a string) and kept out of the property bag.
         """
-        create_nodes_query = """
-        UNWIND keys($data) AS labelsString
-
-        WITH split(labelsString, ",") AS labels, $data[labelsString] AS nodesProperties
-
-        UNWIND nodesProperties AS nodeProperties
-        CALL apoc.create.node(labels, nodeProperties) YIELD node AS n
-
-        RETURN elementId(n) AS internal_id, nodeProperties.uid AS uid
-        """
-        # MERGE deduplicated nodes on their content hash so repeated imports of the same
-        # Reference / ConceptDescription converge to a single node across client instances.
-        merge_nodes_query = """
-        UNWIND keys($data) AS labelsString
-
-        WITH split(labelsString, ",") AS labels, $data[labelsString] AS nodesProperties
-
-        UNWIND nodesProperties AS nodeProperties
-        CALL apoc.merge.node(labels, {hash: nodeProperties.hash}, nodeProperties, {}) YIELD node AS n
-
-        RETURN elementId(n) AS internal_id, nodeProperties.uid AS uid
-        """
-        # MERGE on `id` (not hash) for types in deduplicated_by_id: a globally-identified
-        # Identifiable (e.g. ConceptDescription) re-emitted with differing content under the
-        # same id collapses to one node (first-content-wins via empty onMatch), instead of
-        # producing a second node that violates the id-uniqueness constraint.
-        merge_by_id_query = """
-        UNWIND keys($data) AS labelsString
-
-        WITH split(labelsString, ",") AS labels, $data[labelsString] AS nodesProperties
-
-        UNWIND nodesProperties AS nodeProperties
-        CALL apoc.merge.node(labels, {id: nodeProperties.id}, nodeProperties, {}) YIELD node AS n
-
-        RETURN elementId(n) AS internal_id, nodeProperties.uid AS uid
-        """
-
         dedup_by_id = set(self.model_config.deduplicated_by_id)
+        create: Dict[str, List[Dict]] = {}
+        merge_by_hash: Dict[str, List[Dict]] = {}
+        merge_by_id: Dict[str, List[Dict]] = {}
+        merged_uids: set = set()
+        known_uids: set = {str(uid) for uid in exist_uid_to_internal_id or {}}
 
-        # Route each label bucket: MERGE-by-id for dedup-by-id types (keyed on the
-        # Identifiable `id`, which carries a uniqueness constraint), MERGE-by-hash for
-        # content-deduplicated types (they carry a `hash` from _deduplicate_nodes), plain
-        # CREATE otherwise. By-id routing is decided by the labels alone — a dedup-by-id
-        # type does not need a content hash, so no `hash` property is written for it.
-        merge_data: Dict[str, List[Dict]] = {}
-        merge_by_id_data: Dict[str, List[Dict]] = {}
-        create_data: Dict[str, List[Dict]] = {}
         for label_tuple, node_list in grouped_nodes.items():
             key = ",".join(label_tuple)
-            if dedup_by_id.intersection(label_tuple):
-                merge_by_id_data[key] = node_list
-                continue
-            dedup = [n for n in node_list if "hash" in n]
-            plain = [n for n in node_list if "hash" not in n]
-            if dedup:
-                merge_data[key] = dedup
-            if plain:
-                create_data[key] = plain
+            by_id = bool(dedup_by_id.intersection(label_tuple))
+            for node in node_list:
+                uid = str(node["uid"])
+                known_uids.add(uid)
+                row = {"uid": uid, "props": {k: v for k, v in node.items() if k != "uid"}}
+                if by_id:
+                    merge_by_id.setdefault(key, []).append(row)
+                elif "hash" in node:
+                    merge_by_hash.setdefault(key, []).append(row)
+                    merged_uids.add(uid)
+                else:
+                    create.setdefault(key, []).append(row)
 
-        uid_to_internal_id = {}
-        if create_data:
-            for record in session.run(create_nodes_query, data=create_data):
-                uid_to_internal_id[record['uid']] = record['internal_id']
-        if merge_data:
-            for record in session.run(merge_nodes_query, data=merge_data):
-                uid_to_internal_id[record['uid']] = record['internal_id']
-        if merge_by_id_data:
-            for record in session.run(merge_by_id_query, data=merge_by_id_data):
-                uid_to_internal_id[record['uid']] = record['internal_id']
-
-        return uid_to_internal_id
-
-    def _create_relationships(self, session: Session, relationships: Dict[str, List],
-                              uid_to_internal_id: Dict[int, int], db_batch_size: int = 10000):
-        """Create relationships in Neo4j."""
-        # MERGE (not CREATE) so a relationship onto a reused deduplicated node is not
-        # duplicated when the same edge is seen again by a later import. The relationship
-        # properties (e.g. list_index) are part of the merge key, so distinct list
-        # positions remain distinct edges.
-        create_rels_query = """
-        UNWIND $relationships AS rel
-        MATCH (from_node) WHERE elementId(from_node) = rel.from_id
-        MATCH (to_node) WHERE elementId(to_node) = rel.to_id
-        CALL apoc.merge.relationship(from_node, rel.rel_type, rel.rel_props, {}, to_node, {}) YIELD rel AS r
-        RETURN count(*) AS created
-        """
-
-        all_rels = []
+        create_rels: Dict[str, List[Dict]] = {}
+        merge_rels: List[Dict] = []
         for rel_type, rel_list in relationships.items():
             for rel in rel_list:
-                try:
-                    all_rels.append({
-                        'from_id': uid_to_internal_id[rel['from_uid']],
-                        'to_id': uid_to_internal_id[rel['to_uid']],
-                        'rel_type': rel_type,
-                        'rel_props': rel['rel_props']
-                    })
-                except KeyError:
+                from_uid, to_uid = str(rel["from_uid"]), str(rel["to_uid"])
+                if from_uid not in known_uids or to_uid not in known_uids:
                     logger.warning(
-                        f"Skipping relationship {rel_type} from {rel['from_uid']} to {rel['to_uid']} due to missing UID mapping.")
+                        f"Skipping relationship {rel_type} from {from_uid} to {to_uid} due to missing UID mapping.")
+                    continue
+                row = {"from": from_uid, "to": to_uid, "props": rel["rel_props"]}
+                if from_uid in merged_uids:
+                    merge_rels.append({"type": rel_type, **row})
+                else:
+                    create_rels.setdefault(rel_type, []).append(row)
+        return create, merge_by_hash, merge_by_id, create_rels, merge_rels
 
-        created_rels = 0
-        for i in range(0, len(all_rels), db_batch_size):
-            batch = all_rels[i:i + db_batch_size]
-            # Do not swallow a TransientError here: it would drop the whole batch of edges
-            # while reporting success, silently corrupting the graph. Let it propagate so the
-            # caller's transaction/retry handling surfaces the failure (node creation behaves
-            # the same way).
-            result = session.run(create_rels_query, relationships=batch)
-            created_rels += result.single()['created']
+    def _write_graph(self, session: Session, grouped_nodes: Dict[Tuple[str], List[Dict]],
+                     relationships: Dict[str, List],
+                     exist_uid_to_internal_id: Optional[Dict] = None) -> int:
+        """Write a batch's nodes and relationships in one query; return the edge count.
 
-        return created_rels
+        A TransientError is not caught here: swallowing it would drop the batch while
+        reporting success, silently corrupting the graph. Let it reach the caller's
+        transaction/retry handling.
+        """
+        create, merge_by_hash, merge_by_id, create_rels, merge_rels = self._write_buckets(
+            grouped_nodes, relationships, exist_uid_to_internal_id or {})
+        record = session.run(
+            self._WRITE_GRAPH_QUERY,
+            create=create,
+            merge_by_hash=merge_by_hash,
+            merge_by_id=merge_by_id,
+            existing={str(uid): eid for uid, eid in (exist_uid_to_internal_id or {}).items()},
+            create_rels=create_rels,
+            merge_rels=merge_rels,
+        ).single()
+        return record["relationships"]
+
+    @contextmanager
+    def _overlapped_writes(self):
+        """Yield ``submit(nodes, relationships, stats, db_batch_size)`` for a bulk loader.
+
+        The submitted batch is written on a background thread while the caller decodes and
+        maps the next one — a bulk load spends roughly a third of its time on the source
+        side and the rest writing, and overlapping hides the smaller of the two.
+
+        Exactly one writer thread, never more: deduplication state and the "already stored"
+        check that skips a duplicate Identifiable's subtree are only correct while writes
+        are serialized. Two concurrent writers each see the same id as not-yet-stored and
+        both write its subtree (measured: +0.4 % nodes at two workers, and no faster than
+        this at four — the write is lock-bound, not CPU-bound).
+
+        A failed write surfaces at the next ``submit`` or when the block exits, so a bulk
+        load still fails loudly instead of reporting success on a dropped batch.
+        """
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="neo4aas-write")
+        pending = []
+
+        def submit(nodes, relationships, stats, db_batch_size):
+            while pending:
+                pending.pop().result()
+            pending.append(executor.submit(self._upload_nodes_and_relationships, nodes,
+                                           relationships, stats, db_batch_size=db_batch_size))
+
+        try:
+            yield submit
+            while pending:
+                pending.pop().result()
+        finally:
+            executor.shutdown(wait=True)
 
     def _stored_identifiable_ids(self, ids: List[str]) -> set:
         """Which of these Identifiable ids already exist in the database.
@@ -312,13 +351,15 @@ class JsonToNeo4jImporter(BaseNeo4JClient):
                 rel["from_uid"] = self.deduplicated_to_existing_uid_map.get(rel["from_uid"], rel["from_uid"])
                 rel["to_uid"] = self.deduplicated_to_existing_uid_map.get(rel["to_uid"], rel["to_uid"])
 
-                # Deterministic JSON hash from relationship type and properties
-                hash_value = hashlib.sha256(
-                    json.dumps({"_type": rel_type, **rel}, sort_keys=True).encode()
-                ).hexdigest()
+                # Identity of an edge is its type, endpoints and properties. A tuple key is
+                # used rather than a hash of a JSON dump: the key is never stored (unlike a
+                # node `hash`, which the database MERGEs on), and hashing every edge of a
+                # batch through json.dumps + sha256 costs more than the write it guards.
+                key = (rel_type, rel["from_uid"], rel["to_uid"],
+                       tuple(sorted(rel["rel_props"].items())))
 
-                if hash_value not in self.deduplicated_rels:
-                    self.deduplicated_rels.add(hash_value)
+                if key not in self.deduplicated_rels:
+                    self.deduplicated_rels.add(key)
                     updated_rels.append(rel)
 
             # Replace with deduplicated and updated relationships
@@ -342,7 +383,6 @@ class JsonToNeo4jImporter(BaseNeo4JClient):
         self.deduplicated_nodes.clear()
         self.deduplicated_to_existing_uid_map.clear()
         self.deduplicated_rels.clear()
-        self.uid_to_internal_id.clear()
         # Invalidate the cached containment relationship-type filter (AASNeo4JClient): this
         # upload may introduce a new relationship type (e.g. the first :submodels edge when a
         # shell is stored after its submodel), and a stale cached filter would omit it and break
@@ -363,53 +403,28 @@ class JsonToNeo4jImporter(BaseNeo4JClient):
         relationships = self._deduplicate_rels(relationships)
 
         # --- Continue with database operations ---
+        # One query per batch: nodes and their relationships, with the uid -> node map kept
+        # server-side (see _WRITE_GRAPH_QUERY). `db_batch_size` is accepted for call
+        # compatibility and no longer chunks the write — a batch is one transaction, sized
+        # by the caller's file/environment batch.
+        write_start_time = time.time()
         with self.driver.session() as session:
-            # 1. Create Nodes in Batches
-            node_start_time = time.time()
-            created_map = self._create_nodes(session, grouped_nodes)
-            self.uid_to_internal_id.update(created_map)
-            if exist_uid_to_internal_id:
-                # Merge existing UID to internal ID mapping with newly created nodes
-                self.uid_to_internal_id.update(exist_uid_to_internal_id)
+            relationship_count = self._write_graph(session, grouped_nodes, relationships,
+                                                   exist_uid_to_internal_id)
+        write_time = time.time() - write_start_time
 
-            node_creation_time = time.time() - node_start_time
-            stats.total_node_creation_time += node_creation_time
-            node_count = sum(len(nodes) for nodes in grouped_nodes.values())
-            stats.total_nodes_created += node_count
-            logger.info(f"Created {node_count} nodes in {node_creation_time:.2f} seconds")
-
-            # 2. Create Relationships in Batches
-            rel_start_time = time.time()
-            relationship_count = self._create_relationships(session, relationships, self.uid_to_internal_id, db_batch_size)
-            relationship_creation_time = time.time() - rel_start_time
-            stats.total_relationship_creation_time += relationship_creation_time
-            stats.total_relationships_created += relationship_count
-            logger.info(f"Created {relationship_count} relationships in {relationship_creation_time:.2f} seconds")
-
-            # 3. Cleanup UIDs in Batches — uid is an import-internal tracking property and
-            # must not persist on nodes. Only this batch's nodes are touched (the in-memory
-            # uid -> elementId map is kept for later relationship wiring). hash is preserved
-            # for deduplication.
-            self._cleanup_uids_in_session(session, list(created_map.values()), db_batch_size)
+        node_count = sum(len(bucket) for bucket in grouped_nodes.values())
+        # The single query no longer separates the two phases; attribute its time to node
+        # creation and keep the relationship counter exact.
+        stats.total_node_creation_time += write_time
+        stats.total_nodes_created += node_count
+        stats.total_relationships_created += relationship_count
+        logger.info(f"Wrote {node_count} nodes and {relationship_count} relationships "
+                    f"in {write_time:.2f} seconds")
 
         del grouped_nodes
 
         return stats
-
-    def _cleanup_uids_in_session(self, session: Session, internal_ids: List[int], batch_size: int):
-        """Removes `uid` property from nodes in batches within an existing session."""
-        delete_query = """
-        UNWIND $ids AS id
-        MATCH (n)
-        WHERE elementId(n) = id
-        REMOVE n.uid
-        """
-        for i in range(0, len(internal_ids), batch_size):
-            batch_ids = internal_ids[i:i + batch_size]
-            try:
-                session.run(delete_query, ids=batch_ids)
-            except ClientError as e:
-                logging.warning(f"Error during UID cleanup for batch: {e}")
 
     @staticmethod
     def identify_labels(obj: Dict):
@@ -568,35 +583,37 @@ class JsonToNeo4jImporter(BaseNeo4JClient):
         logger.info(f"File batch size: {stats.total_batches} batches of {file_batch_size} files each")
         logger.info(f"Database transaction batch size: {db_batch_size}")
 
-        # Process files in batches
-        for batch_num in range(stats.total_batches):
-            start_idx = batch_num * file_batch_size
-            end_idx = min(start_idx + file_batch_size, stats.total_files)
-            current_file_batch = json_files[start_idx:end_idx]
+        # Process files in batches, writing each batch while the next is decoded.
+        with self._overlapped_writes() as submit:
+            # Process files in batches
+            for batch_num in range(stats.total_batches):
+                start_idx = batch_num * file_batch_size
+                end_idx = min(start_idx + file_batch_size, stats.total_files)
+                current_file_batch = json_files[start_idx:end_idx]
 
-            logger.info(f"\n--- Processing Batch {batch_num + 1}/{stats.total_batches} ---")
-            logger.info(f"Files {start_idx + 1}-{end_idx} of {stats.total_files}")
+                logger.info(f"\n--- Processing Batch {batch_num + 1}/{stats.total_batches} ---")
+                logger.info(f"Files {start_idx + 1}-{end_idx} of {stats.total_files}")
 
-            # Process current batch
-            batch_start_time = time.time()
-            batch_nodes, batch_relationships = self._process_json_files_batch(directory, current_file_batch)
+                # Process current batch
+                batch_start_time = time.time()
+                batch_nodes, batch_relationships = self._process_json_files_batch(directory, current_file_batch)
 
-            processing_time = time.time() - batch_start_time
-            stats.total_processing_time += processing_time
-            logger.info(f"Processed {len(current_file_batch)} files in {processing_time:.2f} seconds")
+                processing_time = time.time() - batch_start_time
+                stats.total_processing_time += processing_time
+                logger.info(f"Processed {len(current_file_batch)} files in {processing_time:.2f} seconds")
 
-            if not batch_nodes:
-                logger.info("No nodes to create in this batch, skipping...")
-                continue
+                if not batch_nodes:
+                    logger.info("No nodes to create in this batch, skipping...")
+                    continue
 
-            self._upload_nodes_and_relationships(batch_nodes, batch_relationships, stats, db_batch_size=db_batch_size)
+                submit(batch_nodes, batch_relationships, stats, db_batch_size)
 
-            batch_total_time = time.time() - batch_start_time
-            logger.info(f"Batch {batch_num + 1} completed in {batch_total_time:.2f} seconds")
+                batch_total_time = time.time() - batch_start_time
+                logger.info(f"Batch {batch_num + 1} completed in {batch_total_time:.2f} seconds")
 
-            if batch_num == max_num_of_batches:
-                logger.warning("Max number of batches reached")
-                break
+                if batch_num == max_num_of_batches:
+                    logger.warning("Max number of batches reached")
+                    break
 
         stats.finish()
         return stats

--- a/src/neo4aas/core/serialization/xml/importer.py
+++ b/src/neo4aas/core/serialization/xml/importer.py
@@ -56,41 +56,42 @@ class XmlToNeo4jImporter(JsonToNeo4jImporter):
         logger.info(f"File batch size: {stats.total_batches} batches of {file_batch_size} files each")
         logger.info(f"Database transaction batch size: {db_batch_size}")
 
-        for batch_num in range(stats.total_batches):
-            start_idx = batch_num * file_batch_size
-            end_idx = min(start_idx + file_batch_size, stats.total_files)
-            current_file_batch = xml_files[start_idx:end_idx]
+        # Each batch is written while the next one is parsed (see _overlapped_writes).
+        with self._overlapped_writes() as submit:
+            for batch_num in range(stats.total_batches):
+                start_idx = batch_num * file_batch_size
+                end_idx = min(start_idx + file_batch_size, stats.total_files)
+                current_file_batch = xml_files[start_idx:end_idx]
 
-            logger.info(f"\n--- Processing Batch {batch_num + 1}/{stats.total_batches} ---")
-            logger.info(f"Files {start_idx + 1}-{end_idx} of {stats.total_files}")
+                logger.info(f"\n--- Processing Batch {batch_num + 1}/{stats.total_batches} ---")
+                logger.info(f"Files {start_idx + 1}-{end_idx} of {stats.total_files}")
 
-            batch_start_time = time.time()
-            batch_nodes = []
-            batch_relationships = {}
+                batch_start_time = time.time()
+                batch_nodes = []
+                batch_relationships = {}
 
-            for filename in current_file_batch:
-                xml_dict = xml_to_aas_json(join(directory, filename))
-                nodes, relationships = self._process_json_data(xml_dict)
-                batch_nodes.extend(nodes)
-                self._merge_relationships(batch_relationships, relationships)
+                for filename in current_file_batch:
+                    xml_dict = xml_to_aas_json(join(directory, filename))
+                    nodes, relationships = self._process_json_data(xml_dict)
+                    batch_nodes.extend(nodes)
+                    self._merge_relationships(batch_relationships, relationships)
 
-            processing_time = time.time() - batch_start_time
-            stats.total_processing_time += processing_time
-            logger.info(f"Processed {len(current_file_batch)} files in {processing_time:.2f} seconds")
+                processing_time = time.time() - batch_start_time
+                stats.total_processing_time += processing_time
+                logger.info(f"Processed {len(current_file_batch)} files in {processing_time:.2f} seconds")
 
-            if not batch_nodes:
-                logger.info("No nodes to create in this batch, skipping...")
-                continue
+                if not batch_nodes:
+                    logger.info("No nodes to create in this batch, skipping...")
+                    continue
 
-            self._upload_nodes_and_relationships(batch_nodes, batch_relationships, stats,
-                                                 db_batch_size=db_batch_size)
+                submit(batch_nodes, batch_relationships, stats, db_batch_size)
 
-            batch_total_time = time.time() - batch_start_time
-            logger.info(f"Batch {batch_num + 1} completed in {batch_total_time:.2f} seconds")
+                batch_total_time = time.time() - batch_start_time
+                logger.info(f"Batch {batch_num + 1} completed in {batch_total_time:.2f} seconds")
 
-            if batch_num == max_num_of_batches:
-                logger.warning("Max number of batches reached")
-                break
+                if batch_num == max_num_of_batches:
+                    logger.warning("Max number of batches reached")
+                    break
 
         stats.finish()
         return stats

--- a/tests/core/serialization/json/test_importer.py
+++ b/tests/core/serialization/json/test_importer.py
@@ -15,18 +15,73 @@ class _RaisingSession:
         raise TransientError("simulated deadlock")
 
 
-def test_transient_error_during_relationship_creation_is_not_swallowed():
-    """A TransientError while creating relationships must propagate, not be swallowed.
+def test_transient_error_during_graph_write_is_not_swallowed():
+    """A TransientError while writing a batch must propagate, not be swallowed.
 
-    Swallowing it would drop the whole batch of edges while reporting success, silently
-    corrupting the graph. Correct behaviour is to surface the failure to the caller.
+    Swallowing it would drop the whole batch while reporting success, silently corrupting
+    the graph. Correct behaviour is to surface the failure to the caller.
     """
     importer = JsonToNeo4jImporter(uri=None, user="x")  # driver is None; no Neo4j needed
+    grouped = {("Property",): [{"uid": 1, "idShort": "a"}, {"uid": 2, "idShort": "b"}]}
     relationships = {"value": [{"from_uid": 1, "to_uid": 2, "rel_props": {}}]}
-    uid_to_internal_id = {1: "e1", 2: "e2"}
 
     with pytest.raises(TransientError):
-        importer._create_relationships(_RaisingSession(), relationships, uid_to_internal_id)
+        importer._write_graph(_RaisingSession(), grouped, relationships)
+
+
+def test_only_edges_leaving_a_hash_merged_node_are_merged():
+    """Relationship writes split by whether the *source* node may already exist.
+
+    A node created in this batch cannot have the edge already, so its edges are CREATEd —
+    MERGE on a relationship costs ~4x a CREATE and is the single most expensive part of a
+    bulk import. Only a node MERGEd on its content hash can be one the database already
+    holds, complete with the edge, so only its outgoing edges need MERGE.
+    """
+    importer = JsonToNeo4jImporter(uri=None, user="x")
+    grouped = {
+        ("Property",): [{"uid": 1, "idShort": "a"}],
+        ("Reference",): [{"uid": 2, "hash": "h"}],
+    }
+    relationships = {
+        "semanticId": [{"from_uid": 1, "to_uid": 2, "rel_props": {}}],
+        "referredSemanticId": [{"from_uid": 2, "to_uid": 1, "rel_props": {}}],
+    }
+
+    _, _, _, create_rels, merge_rels = importer._write_buckets(grouped, relationships, {})
+
+    assert list(create_rels) == ["semanticId"]
+    assert create_rels["semanticId"] == [{"from": "1", "to": "2", "props": {}}]
+    assert merge_rels == [{"type": "referredSemanticId", "from": "2", "to": "1", "props": {}}]
+
+
+def test_relationship_with_an_unmapped_endpoint_is_dropped():
+    """An edge whose endpoint was not written (e.g. a dropped duplicate subtree) is skipped.
+
+    It cannot be created — the server-side uid map has no node for it — and passing it on
+    would make the whole batch fail on a null endpoint.
+    """
+    importer = JsonToNeo4jImporter(uri=None, user="x")
+    grouped = {("Property",): [{"uid": 1, "idShort": "a"}]}
+    relationships = {"value": [{"from_uid": 1, "to_uid": 99, "rel_props": {}}]}
+
+    _, _, _, create_rels, merge_rels = importer._write_buckets(grouped, relationships, {})
+
+    assert create_rels == {}
+    assert merge_rels == []
+
+
+def test_uid_is_not_part_of_the_written_properties():
+    """`uid` is import-internal bookkeeping and must never reach the property bag.
+
+    It used to be written with the node and deleted again by a second pass over every
+    node; keeping it out of `props` removes both the write and the pass.
+    """
+    importer = JsonToNeo4jImporter(uri=None, user="x")
+    grouped = {("Property",): [{"uid": 7, "idShort": "a"}]}
+
+    create, _, _, _, _ = importer._write_buckets(grouped, {}, {})
+
+    assert create == {"Property": [{"uid": "7", "props": {"idShort": "a"}}]}
 
 
 def test_group_nodes_by_label_does_not_mutate_input():
@@ -116,3 +171,41 @@ def test_process_json_file_reads_gzipped_source(tmp_path):
     nodes, _ = importer._process_json_file(str(path))
 
     assert any(n.get("id") == "urn:gz" for n in nodes)
+
+
+def test_overlapped_writes_run_off_the_calling_thread_and_in_order():
+    """A bulk loader's batches are written on one background thread, in submission order.
+
+    Overlapping the write with the decoding of the next batch is where the wall-clock win
+    comes from; a *single* writer is what keeps deduplication and the duplicate-subtree
+    skip correct, so the order must be exactly the submission order.
+    """
+    import threading
+
+    importer = JsonToNeo4jImporter(uri=None, user="x")
+    seen = []
+    importer._upload_nodes_and_relationships = (
+        lambda nodes, rels, stats=None, **kw: seen.append((nodes, threading.get_ident())))
+
+    main = threading.get_ident()
+    with importer._overlapped_writes() as submit:
+        for i in range(4):
+            submit([i], {}, None, 10)
+
+    assert [n for n, _ in seen] == [[0], [1], [2], [3]]
+    writers = {t for _, t in seen}
+    assert len(writers) == 1 and main not in writers
+
+
+def test_a_failed_overlapped_write_is_reported_to_the_caller():
+    """A write that fails on the background thread must not pass as a successful load."""
+    importer = JsonToNeo4jImporter(uri=None, user="x")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("write failed")
+
+    importer._upload_nodes_and_relationships = boom
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        with importer._overlapped_writes() as submit:
+            submit([{"uid": 1}], {}, None, 10)

--- a/tests/core/test_dedup.py
+++ b/tests/core/test_dedup.py
@@ -305,3 +305,42 @@ def test_distinct_identifiables_keep_their_own_subtrees(aas_client):
 
     assert _count_children(aas_client, "urn:sm/a", "submodelElements") == 1
     assert _count_children(aas_client, "urn:sm/b", "submodelElements") == 1
+
+
+def _reference_with_referred_semantic_id(value: str, referred: str) -> dict:
+    return {
+        "type": "ModelReference",
+        "keys": [{"type": "Submodel", "value": value}],
+        "referredSemanticId": {
+            "type": "ExternalReference",
+            "keys": [{"type": "GlobalReference", "value": referred}],
+        },
+    }
+
+
+def test_edge_out_of_a_reused_reference_is_not_duplicated(aas_client, neo4j_params):
+    """A hash-merged Reference reused by a second import keeps a single outgoing edge.
+
+    Relationships are CREATEd, not MERGEd — a node created in the batch cannot already
+    carry the edge, and MERGE on a relationship costs several times a CREATE. The one case
+    where the source node *can* already exist with its edge is a Reference reused through
+    its content hash, so its outgoing `referredSemanticId` must still be MERGEd. Two
+    clients (the second with empty in-memory dedup state) prove the database-level path.
+    """
+    sm = {
+        "modelType": "Submodel",
+        "id": "urn:sm/referred-1",
+        "idShort": "SMR1",
+        "semanticId": _reference_with_referred_semantic_id("urn:target", "0173-REF"),
+    }
+    aas_client.upload_json({"submodels": [sm]})
+    client2 = _second_client(neo4j_params)
+    try:
+        client2.upload_json({"submodels": [dict(sm, id="urn:sm/referred-2", idShort="SMR2")]})
+    finally:
+        client2.driver.close()
+
+    with aas_client.driver.session() as session:
+        assert session.run(
+            "MATCH (r:Reference)-[e:referredSemanticId]->() RETURN count(e) AS c"
+        ).single()["c"] == 1


### PR DESCRIPTION
The database write was **84 % of a bulk import** and cost three round trips per batch plus a
pass over every node:

1. create the nodes, returning a Bolt row each,
2. create the relationships, seeking both endpoints by `elementId` and MERGEing them,
3. `REMOVE n.uid` everywhere.

All three existed only because the `uid -> node` map lived in Python. Kept **server-side**
(`apoc.map.fromPairs`), one statement writes a batch's nodes *and* its relationships and
returns nothing but the edge count. `uid` never reaches the property bag, so the cleanup pass
goes with it.

**Relationships are CREATEd, not MERGEd.** MERGE costs ~4x a CREATE, and an edge can only
pre-exist if its source node is one the database already held — a hash-merged `Reference`,
0.04 % of a corpus batch. Only those still MERGE.

**Bulk loaders overlap the write with the decode.** Each finished batch goes to one background
writer, so batch N is written while batch N+1 is decoded. Exactly one writer: concurrent
writers race the duplicate-Identifiable check and measured no faster.

## Results

| tier | before | after | |
|---|---|---|---|
| t100 | 17.0 s | 9.1 s | 1.9x |
| t1k | 98.7 s | 51.3 s | 1.9x |
| t10k | 756.4 s | 585.9 s | 1.3x |

The graph is unchanged, entity for entity: t1k is 542 073 nodes / 1 060 387 relationships /
5 683 `:references` edges before and after.

Measured against the `aas-corpus` tiers with the new harness `scripts/bench/import_bench.py`,
which times each phase separately (source decode, JSON -> node/edge mapping, deduplication,
each Cypher round trip) so a change is attributed to a phase rather than to the total. Raw
results in `docs/bench/`, method and full write-up in `docs/import-performance.md`.

Based on `aas-demonstrator`.